### PR TITLE
Refactor program sequence. Homed, connected, temperature etc are now controlled by Main (using signals).

### DIFF
--- a/Drivers/Marlin/ACT/LibMCDriver_Marlin.xml
+++ b/Drivers/Marlin/ACT/LibMCDriver_Marlin.xml
@@ -141,7 +141,10 @@ Custom implementation
 			<param name="D" type="double" pass="in" description="New value for D parameter." />
 		</method>
 
-		<method name="UpdateState" description="Polls a new state from the firmware.">
+		<method name="UpdatePositionState" description="Polls a new state from the printer.">
+		</method>
+
+		<method name="UpdateTemperatureState" description="Polls a new temperature state from the printer.">
 			<param name="ExtruderID" type="uint32" pass="in" description="ID of extruder." />
 		</method>
 
@@ -161,15 +164,22 @@ Custom implementation
 			<param name="E" type="double" pass="out" description="E Value in mm" />
 		</method>
 
-		<method name="GetHeatedBedTemperature" description="Returns the current and the target bed temperature.">
+		<method name="GetHeatedBedTargetTemperature" description="Returns the the target bed temperature.">
 			<param name="TargetTemperature" type="double" pass="out" description="Target Temperature in degree celsius." />
+		</method>
+
+		<method name="GetHeatedBedCurrentTemperature" description="Returns the current bed temperature.">
 			<param name="CurrentTemperature" type="double" pass="out" description="Current Temperature in degree celsius." />
 		</method>
 
-		<method name="GetExtruderTemperature" description="Returns the current and the target temperature of an extruder.">
+		<method name="GetExtruderCurrentTemperature" description="Returns the current temperature of an extruder.">
+			<param name="ExtruderID" type="uint32" pass="in" description="ID of Extruder" />
+			<param name="CurrentTemperature" type="double" pass="out" description="Current Temperature in degree celsius." />
+		</method>
+
+		<method name="GetExtruderTargetTemperature" description="Returns the target temperature of an extruder.">
 			<param name="ExtruderID" type="uint32" pass="in" description="ID of Extruder" />
 			<param name="TargetTemperature" type="double" pass="out" description="Target Temperature in degree celsius." />
-			<param name="CurrentTemperature" type="double" pass="out" description="Current Temperature in degree celsius." />
 		</method>
 
 		<method name="GetPidParameters" description="Returns the current PID values.">
@@ -223,6 +233,26 @@ Custom implementation
 		</method>
 
 		<method name="EmergencyStop" description="Used for emergency stopping. Shuts down the machine, turns off all the steppers and heaters, and if possible, turns off the power supply.">
+		</method>
+
+		<method name="SetAxisPosition" description="Set the current position of given axis to the specified value.">
+			<param name="Axis" type="string" pass="in" description="Axis whose value is to be set." />
+			<param name="Value" type="double" pass="in" description="New value for given Axis." />
+		</method>
+
+		<method name="ExtruderDoExtrude" description="Extrudes the specified value with given Feedrate.">
+			<param name="E" type="double" pass="in" description="E value in mm" />
+			<param name="Speed" type="double" pass="in" description="Extrusion speed in mm/s" />
+		</method>
+
+		<method name="SetAbsoluteExtrusion" description="Sets the extrusion (E axis) to absolute mode.">
+			<param name="Absolute" type="bool" pass="in" description="If true, sets mode to absolute, if false to relative" />
+		</method>
+		
+		<method name="StopIdleHold" description="Stop the idle hold on all axis and extruder.">
+		</method>
+
+		<method name="PowerOff" description="Turn off the high-voltage power supply.">
 		</method>
 
 	</class>

--- a/Drivers/Marlin/Headers/CppDynamic/libmcdriver_marlin_abi.hpp
+++ b/Drivers/Marlin/Headers/CppDynamic/libmcdriver_marlin_abi.hpp
@@ -191,13 +191,21 @@ LIBMCDRIVER_MARLIN_DECLSPEC LibMCDriver_MarlinResult libmcdriver_marlin_driver_m
 LIBMCDRIVER_MARLIN_DECLSPEC LibMCDriver_MarlinResult libmcdriver_marlin_driver_marlin_setpidparameters(LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin, LibMCDriver_Marlin_double dP, LibMCDriver_Marlin_double dI, LibMCDriver_Marlin_double dD);
 
 /**
-* Polls a new state from the firmware.
+* Polls a new state from the printer.
+*
+* @param[in] pDriver_Marlin - Driver_Marlin instance.
+* @return error code or 0 (success)
+*/
+LIBMCDRIVER_MARLIN_DECLSPEC LibMCDriver_MarlinResult libmcdriver_marlin_driver_marlin_updatepositionstate(LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin);
+
+/**
+* Polls a new temperature state from the printer.
 *
 * @param[in] pDriver_Marlin - Driver_Marlin instance.
 * @param[in] nExtruderID - ID of extruder.
 * @return error code or 0 (success)
 */
-LIBMCDRIVER_MARLIN_DECLSPEC LibMCDriver_MarlinResult libmcdriver_marlin_driver_marlin_updatestate(LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin, LibMCDriver_Marlin_uint32 nExtruderID);
+LIBMCDRIVER_MARLIN_DECLSPEC LibMCDriver_MarlinResult libmcdriver_marlin_driver_marlin_updatetemperaturestate(LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin, LibMCDriver_Marlin_uint32 nExtruderID);
 
 /**
 * Returns the current axis position.
@@ -231,25 +239,42 @@ LIBMCDRIVER_MARLIN_DECLSPEC LibMCDriver_MarlinResult libmcdriver_marlin_driver_m
 LIBMCDRIVER_MARLIN_DECLSPEC LibMCDriver_MarlinResult libmcdriver_marlin_driver_marlin_getextrudertargetposition(LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin, LibMCDriver_Marlin_double * pE);
 
 /**
-* Returns the current and the target bed temperature.
+* Returns the the target bed temperature.
 *
 * @param[in] pDriver_Marlin - Driver_Marlin instance.
 * @param[out] pTargetTemperature - Target Temperature in degree celsius.
+* @return error code or 0 (success)
+*/
+LIBMCDRIVER_MARLIN_DECLSPEC LibMCDriver_MarlinResult libmcdriver_marlin_driver_marlin_getheatedbedtargettemperature(LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin, LibMCDriver_Marlin_double * pTargetTemperature);
+
+/**
+* Returns the current bed temperature.
+*
+* @param[in] pDriver_Marlin - Driver_Marlin instance.
 * @param[out] pCurrentTemperature - Current Temperature in degree celsius.
 * @return error code or 0 (success)
 */
-LIBMCDRIVER_MARLIN_DECLSPEC LibMCDriver_MarlinResult libmcdriver_marlin_driver_marlin_getheatedbedtemperature(LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin, LibMCDriver_Marlin_double * pTargetTemperature, LibMCDriver_Marlin_double * pCurrentTemperature);
+LIBMCDRIVER_MARLIN_DECLSPEC LibMCDriver_MarlinResult libmcdriver_marlin_driver_marlin_getheatedbedcurrenttemperature(LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin, LibMCDriver_Marlin_double * pCurrentTemperature);
 
 /**
-* Returns the current and the target temperature of an extruder.
+* Returns the current temperature of an extruder.
+*
+* @param[in] pDriver_Marlin - Driver_Marlin instance.
+* @param[in] nExtruderID - ID of Extruder
+* @param[out] pCurrentTemperature - Current Temperature in degree celsius.
+* @return error code or 0 (success)
+*/
+LIBMCDRIVER_MARLIN_DECLSPEC LibMCDriver_MarlinResult libmcdriver_marlin_driver_marlin_getextrudercurrenttemperature(LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin, LibMCDriver_Marlin_uint32 nExtruderID, LibMCDriver_Marlin_double * pCurrentTemperature);
+
+/**
+* Returns the target temperature of an extruder.
 *
 * @param[in] pDriver_Marlin - Driver_Marlin instance.
 * @param[in] nExtruderID - ID of Extruder
 * @param[out] pTargetTemperature - Target Temperature in degree celsius.
-* @param[out] pCurrentTemperature - Current Temperature in degree celsius.
 * @return error code or 0 (success)
 */
-LIBMCDRIVER_MARLIN_DECLSPEC LibMCDriver_MarlinResult libmcdriver_marlin_driver_marlin_getextrudertemperature(LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin, LibMCDriver_Marlin_uint32 nExtruderID, LibMCDriver_Marlin_double * pTargetTemperature, LibMCDriver_Marlin_double * pCurrentTemperature);
+LIBMCDRIVER_MARLIN_DECLSPEC LibMCDriver_MarlinResult libmcdriver_marlin_driver_marlin_getextrudertargettemperature(LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin, LibMCDriver_Marlin_uint32 nExtruderID, LibMCDriver_Marlin_double * pTargetTemperature);
 
 /**
 * Returns the current PID values.
@@ -357,6 +382,51 @@ LIBMCDRIVER_MARLIN_DECLSPEC LibMCDriver_MarlinResult libmcdriver_marlin_driver_m
 * @return error code or 0 (success)
 */
 LIBMCDRIVER_MARLIN_DECLSPEC LibMCDriver_MarlinResult libmcdriver_marlin_driver_marlin_emergencystop(LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin);
+
+/**
+* Set the current position of given axis to the specified value.
+*
+* @param[in] pDriver_Marlin - Driver_Marlin instance.
+* @param[in] pAxis - Axis whose value is to be set.
+* @param[in] dValue - New value for given Axis.
+* @return error code or 0 (success)
+*/
+LIBMCDRIVER_MARLIN_DECLSPEC LibMCDriver_MarlinResult libmcdriver_marlin_driver_marlin_setaxisposition(LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin, const char * pAxis, LibMCDriver_Marlin_double dValue);
+
+/**
+* Extrudes the specified value with given Feedrate.
+*
+* @param[in] pDriver_Marlin - Driver_Marlin instance.
+* @param[in] dE - E value in mm
+* @param[in] dSpeed - Extrusion speed in mm/s
+* @return error code or 0 (success)
+*/
+LIBMCDRIVER_MARLIN_DECLSPEC LibMCDriver_MarlinResult libmcdriver_marlin_driver_marlin_extruderdoextrude(LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin, LibMCDriver_Marlin_double dE, LibMCDriver_Marlin_double dSpeed);
+
+/**
+* Sets the extrusion (E axis) to absolute mode.
+*
+* @param[in] pDriver_Marlin - Driver_Marlin instance.
+* @param[in] bAbsolute - If true, sets mode to absolute, if false to relative
+* @return error code or 0 (success)
+*/
+LIBMCDRIVER_MARLIN_DECLSPEC LibMCDriver_MarlinResult libmcdriver_marlin_driver_marlin_setabsoluteextrusion(LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin, bool bAbsolute);
+
+/**
+* Stop the idle hold on all axis and extruder.
+*
+* @param[in] pDriver_Marlin - Driver_Marlin instance.
+* @return error code or 0 (success)
+*/
+LIBMCDRIVER_MARLIN_DECLSPEC LibMCDriver_MarlinResult libmcdriver_marlin_driver_marlin_stopidlehold(LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin);
+
+/**
+* Turn off the high-voltage power supply.
+*
+* @param[in] pDriver_Marlin - Driver_Marlin instance.
+* @return error code or 0 (success)
+*/
+LIBMCDRIVER_MARLIN_DECLSPEC LibMCDriver_MarlinResult libmcdriver_marlin_driver_marlin_poweroff(LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin);
 
 /*************************************************************************************************************************
  Global functions

--- a/Drivers/Marlin/Headers/CppDynamic/libmcdriver_marlin_dynamic.h
+++ b/Drivers/Marlin/Headers/CppDynamic/libmcdriver_marlin_dynamic.h
@@ -178,13 +178,21 @@ typedef LibMCDriver_MarlinResult (*PLibMCDriver_MarlinDriver_Marlin_SetFanSpeedP
 typedef LibMCDriver_MarlinResult (*PLibMCDriver_MarlinDriver_Marlin_SetPidParametersPtr) (LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin, LibMCDriver_Marlin_double dP, LibMCDriver_Marlin_double dI, LibMCDriver_Marlin_double dD);
 
 /**
-* Polls a new state from the firmware.
+* Polls a new state from the printer.
+*
+* @param[in] pDriver_Marlin - Driver_Marlin instance.
+* @return error code or 0 (success)
+*/
+typedef LibMCDriver_MarlinResult (*PLibMCDriver_MarlinDriver_Marlin_UpdatePositionStatePtr) (LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin);
+
+/**
+* Polls a new temperature state from the printer.
 *
 * @param[in] pDriver_Marlin - Driver_Marlin instance.
 * @param[in] nExtruderID - ID of extruder.
 * @return error code or 0 (success)
 */
-typedef LibMCDriver_MarlinResult (*PLibMCDriver_MarlinDriver_Marlin_UpdateStatePtr) (LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin, LibMCDriver_Marlin_uint32 nExtruderID);
+typedef LibMCDriver_MarlinResult (*PLibMCDriver_MarlinDriver_Marlin_UpdateTemperatureStatePtr) (LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin, LibMCDriver_Marlin_uint32 nExtruderID);
 
 /**
 * Returns the current axis position.
@@ -218,25 +226,42 @@ typedef LibMCDriver_MarlinResult (*PLibMCDriver_MarlinDriver_Marlin_GetTargetPos
 typedef LibMCDriver_MarlinResult (*PLibMCDriver_MarlinDriver_Marlin_GetExtruderTargetPositionPtr) (LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin, LibMCDriver_Marlin_double * pE);
 
 /**
-* Returns the current and the target bed temperature.
+* Returns the the target bed temperature.
 *
 * @param[in] pDriver_Marlin - Driver_Marlin instance.
 * @param[out] pTargetTemperature - Target Temperature in degree celsius.
+* @return error code or 0 (success)
+*/
+typedef LibMCDriver_MarlinResult (*PLibMCDriver_MarlinDriver_Marlin_GetHeatedBedTargetTemperaturePtr) (LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin, LibMCDriver_Marlin_double * pTargetTemperature);
+
+/**
+* Returns the current bed temperature.
+*
+* @param[in] pDriver_Marlin - Driver_Marlin instance.
 * @param[out] pCurrentTemperature - Current Temperature in degree celsius.
 * @return error code or 0 (success)
 */
-typedef LibMCDriver_MarlinResult (*PLibMCDriver_MarlinDriver_Marlin_GetHeatedBedTemperaturePtr) (LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin, LibMCDriver_Marlin_double * pTargetTemperature, LibMCDriver_Marlin_double * pCurrentTemperature);
+typedef LibMCDriver_MarlinResult (*PLibMCDriver_MarlinDriver_Marlin_GetHeatedBedCurrentTemperaturePtr) (LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin, LibMCDriver_Marlin_double * pCurrentTemperature);
 
 /**
-* Returns the current and the target temperature of an extruder.
+* Returns the current temperature of an extruder.
+*
+* @param[in] pDriver_Marlin - Driver_Marlin instance.
+* @param[in] nExtruderID - ID of Extruder
+* @param[out] pCurrentTemperature - Current Temperature in degree celsius.
+* @return error code or 0 (success)
+*/
+typedef LibMCDriver_MarlinResult (*PLibMCDriver_MarlinDriver_Marlin_GetExtruderCurrentTemperaturePtr) (LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin, LibMCDriver_Marlin_uint32 nExtruderID, LibMCDriver_Marlin_double * pCurrentTemperature);
+
+/**
+* Returns the target temperature of an extruder.
 *
 * @param[in] pDriver_Marlin - Driver_Marlin instance.
 * @param[in] nExtruderID - ID of Extruder
 * @param[out] pTargetTemperature - Target Temperature in degree celsius.
-* @param[out] pCurrentTemperature - Current Temperature in degree celsius.
 * @return error code or 0 (success)
 */
-typedef LibMCDriver_MarlinResult (*PLibMCDriver_MarlinDriver_Marlin_GetExtruderTemperaturePtr) (LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin, LibMCDriver_Marlin_uint32 nExtruderID, LibMCDriver_Marlin_double * pTargetTemperature, LibMCDriver_Marlin_double * pCurrentTemperature);
+typedef LibMCDriver_MarlinResult (*PLibMCDriver_MarlinDriver_Marlin_GetExtruderTargetTemperaturePtr) (LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin, LibMCDriver_Marlin_uint32 nExtruderID, LibMCDriver_Marlin_double * pTargetTemperature);
 
 /**
 * Returns the current PID values.
@@ -345,6 +370,51 @@ typedef LibMCDriver_MarlinResult (*PLibMCDriver_MarlinDriver_Marlin_StartHomingP
 */
 typedef LibMCDriver_MarlinResult (*PLibMCDriver_MarlinDriver_Marlin_EmergencyStopPtr) (LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin);
 
+/**
+* Set the current position of given axis to the specified value.
+*
+* @param[in] pDriver_Marlin - Driver_Marlin instance.
+* @param[in] pAxis - Axis whose value is to be set.
+* @param[in] dValue - New value for given Axis.
+* @return error code or 0 (success)
+*/
+typedef LibMCDriver_MarlinResult (*PLibMCDriver_MarlinDriver_Marlin_SetAxisPositionPtr) (LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin, const char * pAxis, LibMCDriver_Marlin_double dValue);
+
+/**
+* Extrudes the specified value with given Feedrate.
+*
+* @param[in] pDriver_Marlin - Driver_Marlin instance.
+* @param[in] dE - E value in mm
+* @param[in] dSpeed - Extrusion speed in mm/s
+* @return error code or 0 (success)
+*/
+typedef LibMCDriver_MarlinResult (*PLibMCDriver_MarlinDriver_Marlin_ExtruderDoExtrudePtr) (LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin, LibMCDriver_Marlin_double dE, LibMCDriver_Marlin_double dSpeed);
+
+/**
+* Sets the extrusion (E axis) to absolute mode.
+*
+* @param[in] pDriver_Marlin - Driver_Marlin instance.
+* @param[in] bAbsolute - If true, sets mode to absolute, if false to relative
+* @return error code or 0 (success)
+*/
+typedef LibMCDriver_MarlinResult (*PLibMCDriver_MarlinDriver_Marlin_SetAbsoluteExtrusionPtr) (LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin, bool bAbsolute);
+
+/**
+* Stop the idle hold on all axis and extruder.
+*
+* @param[in] pDriver_Marlin - Driver_Marlin instance.
+* @return error code or 0 (success)
+*/
+typedef LibMCDriver_MarlinResult (*PLibMCDriver_MarlinDriver_Marlin_StopIdleHoldPtr) (LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin);
+
+/**
+* Turn off the high-voltage power supply.
+*
+* @param[in] pDriver_Marlin - Driver_Marlin instance.
+* @return error code or 0 (success)
+*/
+typedef LibMCDriver_MarlinResult (*PLibMCDriver_MarlinDriver_Marlin_PowerOffPtr) (LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin);
+
 /*************************************************************************************************************************
  Global functions
 **************************************************************************************************************************/
@@ -432,12 +502,15 @@ typedef struct {
 	PLibMCDriver_MarlinDriver_Marlin_SetExtruderTargetTemperaturePtr m_Driver_Marlin_SetExtruderTargetTemperature;
 	PLibMCDriver_MarlinDriver_Marlin_SetFanSpeedPtr m_Driver_Marlin_SetFanSpeed;
 	PLibMCDriver_MarlinDriver_Marlin_SetPidParametersPtr m_Driver_Marlin_SetPidParameters;
-	PLibMCDriver_MarlinDriver_Marlin_UpdateStatePtr m_Driver_Marlin_UpdateState;
+	PLibMCDriver_MarlinDriver_Marlin_UpdatePositionStatePtr m_Driver_Marlin_UpdatePositionState;
+	PLibMCDriver_MarlinDriver_Marlin_UpdateTemperatureStatePtr m_Driver_Marlin_UpdateTemperatureState;
 	PLibMCDriver_MarlinDriver_Marlin_GetCurrentPositionPtr m_Driver_Marlin_GetCurrentPosition;
 	PLibMCDriver_MarlinDriver_Marlin_GetTargetPositionPtr m_Driver_Marlin_GetTargetPosition;
 	PLibMCDriver_MarlinDriver_Marlin_GetExtruderTargetPositionPtr m_Driver_Marlin_GetExtruderTargetPosition;
-	PLibMCDriver_MarlinDriver_Marlin_GetHeatedBedTemperaturePtr m_Driver_Marlin_GetHeatedBedTemperature;
-	PLibMCDriver_MarlinDriver_Marlin_GetExtruderTemperaturePtr m_Driver_Marlin_GetExtruderTemperature;
+	PLibMCDriver_MarlinDriver_Marlin_GetHeatedBedTargetTemperaturePtr m_Driver_Marlin_GetHeatedBedTargetTemperature;
+	PLibMCDriver_MarlinDriver_Marlin_GetHeatedBedCurrentTemperaturePtr m_Driver_Marlin_GetHeatedBedCurrentTemperature;
+	PLibMCDriver_MarlinDriver_Marlin_GetExtruderCurrentTemperaturePtr m_Driver_Marlin_GetExtruderCurrentTemperature;
+	PLibMCDriver_MarlinDriver_Marlin_GetExtruderTargetTemperaturePtr m_Driver_Marlin_GetExtruderTargetTemperature;
 	PLibMCDriver_MarlinDriver_Marlin_GetPidParametersPtr m_Driver_Marlin_GetPidParameters;
 	PLibMCDriver_MarlinDriver_Marlin_CanExecuteMovementPtr m_Driver_Marlin_CanExecuteMovement;
 	PLibMCDriver_MarlinDriver_Marlin_IsMovingPtr m_Driver_Marlin_IsMoving;
@@ -449,6 +522,11 @@ typedef struct {
 	PLibMCDriver_MarlinDriver_Marlin_MoveFastToZPtr m_Driver_Marlin_MoveFastToZ;
 	PLibMCDriver_MarlinDriver_Marlin_StartHomingPtr m_Driver_Marlin_StartHoming;
 	PLibMCDriver_MarlinDriver_Marlin_EmergencyStopPtr m_Driver_Marlin_EmergencyStop;
+	PLibMCDriver_MarlinDriver_Marlin_SetAxisPositionPtr m_Driver_Marlin_SetAxisPosition;
+	PLibMCDriver_MarlinDriver_Marlin_ExtruderDoExtrudePtr m_Driver_Marlin_ExtruderDoExtrude;
+	PLibMCDriver_MarlinDriver_Marlin_SetAbsoluteExtrusionPtr m_Driver_Marlin_SetAbsoluteExtrusion;
+	PLibMCDriver_MarlinDriver_Marlin_StopIdleHoldPtr m_Driver_Marlin_StopIdleHold;
+	PLibMCDriver_MarlinDriver_Marlin_PowerOffPtr m_Driver_Marlin_PowerOff;
 	PLibMCDriver_MarlinGetVersionPtr m_GetVersion;
 	PLibMCDriver_MarlinGetLastErrorPtr m_GetLastError;
 	PLibMCDriver_MarlinReleaseInstancePtr m_ReleaseInstance;

--- a/Drivers/Marlin/Implementation/AMC_SerialController.hpp
+++ b/Drivers/Marlin/Implementation/AMC_SerialController.hpp
@@ -44,8 +44,10 @@ namespace AMC {
 		virtual void queryTemperatureState (uint32_t nExtruderIndex) = 0;
 		virtual void queryPositionState () = 0;
 
-		virtual void getHeatedBedTemperature(double & dTargetTemperature, double & dCurrentTemperature) = 0;
-		virtual void getExtruderTemperature(uint32_t nExtruderIndex, double& dTargetTemperature, double& dCurrentTemperature) = 0;
+		virtual void getHeatedBedTargetTemperature(double& dTargetTemperature) = 0;
+		virtual void getHeatedBedCurrentTemperature(double& dCurrentTemperature) = 0;
+		virtual void getExtruderCurrentTemperature(uint32_t nExtruderIndex, double& dCurrentTemperature) = 0;
+		virtual void getExtruderTargetTemperature(uint32_t nExtruderIndex, double& dTargetTemperature) = 0;
 
 		virtual void getTargetPosition (double & dX, double& dY, double& dZ) = 0;
 		virtual void getCurrentPosition(double& dX, double& dY, double& dZ) = 0;
@@ -60,6 +62,13 @@ namespace AMC {
 
 		virtual void moveZ(const double dZ, const double dE, const double dSpeedInMMperSecond) = 0;
 		virtual void moveFastZ(const double dZ, const double dSpeedInMMperSecond) = 0;
+
+		virtual void setAxisPosition(const std::string& sAxis, double dValue) = 0;
+		virtual void extruderDoExtrude(double dE, double dSpeedInMMperSecond) = 0;
+		virtual void setAbsoluteExtrusion(bool bAbsolute) = 0;
+
+		virtual void stopIdleHold() = 0;
+		virtual void powerOff() = 0;
 
 		virtual bool isHomed() = 0;
 		virtual bool isMoving() = 0;

--- a/Drivers/Marlin/Implementation/AMC_SerialController_Marlin.hpp
+++ b/Drivers/Marlin/Implementation/AMC_SerialController_Marlin.hpp
@@ -107,8 +107,10 @@ namespace AMC {
 		void queryTemperatureState(uint32_t nExtruderIndex) override;
 		void queryPositionState() override;
 
-		void getHeatedBedTemperature(double& dTargetTemperature, double& dCurrentTemperature) override;
-		void getExtruderTemperature(uint32_t nExtruderIndex, double& dTargetTemperature, double& dCurrentTemperature) override;
+		void getHeatedBedCurrentTemperature(double& dCurrentTemperature) override;
+		void getHeatedBedTargetTemperature(double& dTargetTemperature) override;
+		void getExtruderCurrentTemperature(uint32_t nExtruderIndex, double& dCurrentTemperature) override;
+		void getExtruderTargetTemperature(uint32_t nExtruderIndex, double& dTargetTemperature) override;
 
 		void getTargetPosition(double& dX, double& dY, double& dZ) override;
 		void getCurrentPosition(double& dX, double& dY, double& dZ) override;
@@ -123,6 +125,13 @@ namespace AMC {
 		void moveZ(const double dZ, const double dE, const double dSpeedInMMperSecond) override;
 		void moveFastZ(const double dZ, const double dSpeedInMMperSecond) override;
 
+		void setAxisPosition(const std::string& sAxis, double dValue) override;
+		void extruderDoExtrude(double dE, double dSpeedInMMperSecond) override;
+		void setAbsoluteExtrusion(bool bAbsolute) override;
+
+		void stopIdleHold() override;
+		void powerOff() override;
+		
 		bool isHomed() override;
 		bool isMoving() override;
 		bool canReceiveMovement() override;

--- a/Drivers/Marlin/Implementation/libmcdriver_marlin.cpp
+++ b/Drivers/Marlin/Implementation/libmcdriver_marlin.cpp
@@ -80,7 +80,7 @@ IDriver * CWrapper::CreateDriver(const std::string& sName, const std::string& sT
 	}
 
 	if (sType == "marlin-ender-2.0") {
-		bool bDebug = false;
+		bool bDebug = true;
 		bool bDoFirmwareQuery = true;
 		bool bDisableHoming = false;
 

--- a/Drivers/Marlin/Implementation/libmcdriver_marlin_driver_marlin.cpp
+++ b/Drivers/Marlin/Implementation/libmcdriver_marlin_driver_marlin.cpp
@@ -113,13 +113,20 @@ void CDriver_Marlin::SetPidParameters(const LibMCDriver_Marlin_double dP, const 
 	m_pSerialController->setPidParameters(dP, dI, dD);
 }
 
-void CDriver_Marlin::UpdateState(const LibMCDriver_Marlin_uint32 nExtruderID)
+void CDriver_Marlin::UpdateTemperatureState(const LibMCDriver_Marlin_uint32 nExtruderID)
+{
+	if (m_pSerialController.get() == nullptr)
+		throw ELibMCDriver_MarlinInterfaceException(LIBMCDRIVER_MARLIN_ERROR_NOTCONNECTED);
+
+	m_pSerialController->queryTemperatureState(nExtruderID);
+}
+
+void CDriver_Marlin::UpdatePositionState()
 {
 	if (m_pSerialController.get() == nullptr)
 		throw ELibMCDriver_MarlinInterfaceException(LIBMCDRIVER_MARLIN_ERROR_NOTCONNECTED);
 
 	m_pSerialController->queryPositionState();
-	m_pSerialController->queryTemperatureState(nExtruderID);
 }
 
 void CDriver_Marlin::GetCurrentPosition(LibMCDriver_Marlin_double& dX, LibMCDriver_Marlin_double& dY, LibMCDriver_Marlin_double& dZ)
@@ -146,20 +153,36 @@ void CDriver_Marlin::GetExtruderTargetPosition(LibMCDriver_Marlin_double& dE)
 	m_pSerialController->getExtruderTargetPosition(dE);
 }
 
-void CDriver_Marlin::GetHeatedBedTemperature(LibMCDriver_Marlin_double& dTargetTemperature, LibMCDriver_Marlin_double& dCurrentTemperature)
+void CDriver_Marlin::GetHeatedBedTargetTemperature(LibMCDriver_Marlin_double& dTargetTemperature)
 {
 	if (m_pSerialController.get() == nullptr)
 		throw ELibMCDriver_MarlinInterfaceException(LIBMCDRIVER_MARLIN_ERROR_NOTCONNECTED);
 
-	m_pSerialController->getHeatedBedTemperature(dTargetTemperature, dCurrentTemperature);
+	m_pSerialController->getHeatedBedTargetTemperature(dTargetTemperature);
 }
 
-void CDriver_Marlin::GetExtruderTemperature(const LibMCDriver_Marlin_uint32 nExtruderID, LibMCDriver_Marlin_double& dTargetTemperature, LibMCDriver_Marlin_double& dCurrentTemperature)
+void CDriver_Marlin::GetHeatedBedCurrentTemperature( LibMCDriver_Marlin_double& dCurrentTemperature)
 {
 	if (m_pSerialController.get() == nullptr)
 		throw ELibMCDriver_MarlinInterfaceException(LIBMCDRIVER_MARLIN_ERROR_NOTCONNECTED);
 
-	m_pSerialController->getExtruderTemperature(nExtruderID, dTargetTemperature, dCurrentTemperature);
+	m_pSerialController->getHeatedBedCurrentTemperature(dCurrentTemperature);
+}
+
+void CDriver_Marlin::GetExtruderTargetTemperature(const LibMCDriver_Marlin_uint32 nExtruderID, LibMCDriver_Marlin_double& dTargetTemperature)
+{
+	if (m_pSerialController.get() == nullptr)
+		throw ELibMCDriver_MarlinInterfaceException(LIBMCDRIVER_MARLIN_ERROR_NOTCONNECTED);
+
+	m_pSerialController->getExtruderTargetTemperature(nExtruderID, dTargetTemperature);
+}
+
+void CDriver_Marlin::GetExtruderCurrentTemperature(const LibMCDriver_Marlin_uint32 nExtruderID, LibMCDriver_Marlin_double& dCurrentTemperature)
+{
+	if (m_pSerialController.get() == nullptr)
+		throw ELibMCDriver_MarlinInterfaceException(LIBMCDRIVER_MARLIN_ERROR_NOTCONNECTED);
+
+	m_pSerialController->getExtruderCurrentTemperature(nExtruderID, dCurrentTemperature);
 }
 
 void CDriver_Marlin::GetPidParameters(LibMCDriver_Marlin_double& dP, LibMCDriver_Marlin_double& dI, LibMCDriver_Marlin_double& dD)
@@ -250,3 +273,44 @@ void CDriver_Marlin::EmergencyStop()
 
 	m_pSerialController->emergencyStop();
 }
+
+void CDriver_Marlin::SetAxisPosition(const std::string& sAxis, const LibMCDriver_Marlin_double dValue)
+{
+	if (m_pSerialController.get() == nullptr)
+		throw ELibMCDriver_MarlinInterfaceException(LIBMCDRIVER_MARLIN_ERROR_NOTCONNECTED);
+
+	m_pSerialController->setAxisPosition(sAxis, dValue);
+}
+
+void CDriver_Marlin::ExtruderDoExtrude(const LibMCDriver_Marlin_double dE, const LibMCDriver_Marlin_double dSpeed)
+{
+	if (m_pSerialController.get() == nullptr)
+		throw ELibMCDriver_MarlinInterfaceException(LIBMCDRIVER_MARLIN_ERROR_NOTCONNECTED);
+
+	m_pSerialController->extruderDoExtrude(dE, dSpeed);
+}
+
+void CDriver_Marlin::SetAbsoluteExtrusion(const bool bAbsolute)
+{
+	if (m_pSerialController.get() == nullptr)
+		throw ELibMCDriver_MarlinInterfaceException(LIBMCDRIVER_MARLIN_ERROR_NOTCONNECTED);
+
+	m_pSerialController->setAbsoluteExtrusion(bAbsolute);
+}
+
+void CDriver_Marlin::StopIdleHold()
+{
+	if (m_pSerialController.get() == nullptr)
+		throw ELibMCDriver_MarlinInterfaceException(LIBMCDRIVER_MARLIN_ERROR_NOTCONNECTED);
+
+	m_pSerialController->stopIdleHold();
+}
+
+void CDriver_Marlin::PowerOff()
+{
+	if (m_pSerialController.get() == nullptr)
+		throw ELibMCDriver_MarlinInterfaceException(LIBMCDRIVER_MARLIN_ERROR_NOTCONNECTED);
+
+	m_pSerialController->powerOff();
+}
+

--- a/Drivers/Marlin/Implementation/libmcdriver_marlin_driver_marlin.hpp
+++ b/Drivers/Marlin/Implementation/libmcdriver_marlin_driver_marlin.hpp
@@ -60,7 +60,9 @@ public:
 
 	void SetPidParameters(const LibMCDriver_Marlin_double dP, const LibMCDriver_Marlin_double dI, const LibMCDriver_Marlin_double dD) override;
 
-	void UpdateState(const LibMCDriver_Marlin_uint32 nExtruderID) override;
+	void UpdateTemperatureState(const LibMCDriver_Marlin_uint32 nExtruderID) override;
+
+	void UpdatePositionState() override;
 
 	void GetCurrentPosition(LibMCDriver_Marlin_double& dX, LibMCDriver_Marlin_double& dY, LibMCDriver_Marlin_double& dZ) override;
 
@@ -68,9 +70,13 @@ public:
 
 	void GetExtruderTargetPosition(LibMCDriver_Marlin_double& dE) override;
 
-	void GetHeatedBedTemperature(LibMCDriver_Marlin_double& dTargetTemperature, LibMCDriver_Marlin_double& dCurrentTemperature) override;
+	void GetHeatedBedTargetTemperature(LibMCDriver_Marlin_double& dCurrentTemperature) override;
 
-	void GetExtruderTemperature(const LibMCDriver_Marlin_uint32 nExtruderID, LibMCDriver_Marlin_double& dTargetTemperature, LibMCDriver_Marlin_double& dCurrentTemperature) override;
+	void GetHeatedBedCurrentTemperature(LibMCDriver_Marlin_double& dCurrentTemperature) override;
+
+	void GetExtruderTargetTemperature(const LibMCDriver_Marlin_uint32 nExtruderID, LibMCDriver_Marlin_double& dTargetTemperature) override;
+
+	void GetExtruderCurrentTemperature(const LibMCDriver_Marlin_uint32 nExtruderID, LibMCDriver_Marlin_double& dCurrentTemperature) override;
 
 	void GetPidParameters(LibMCDriver_Marlin_double& dP, LibMCDriver_Marlin_double& dI, LibMCDriver_Marlin_double& dD) override;
 
@@ -93,6 +99,16 @@ public:
 	void StartHoming() override;
 
 	void EmergencyStop() override;
+
+	void SetAxisPosition(const std::string& sAxis, const LibMCDriver_Marlin_double dValue) override;
+
+	void ExtruderDoExtrude(const LibMCDriver_Marlin_double dE, const LibMCDriver_Marlin_double dSpeed) override;
+
+	void SetAbsoluteExtrusion(const bool bAbsolute) override;
+
+	void StopIdleHold() override;
+
+	void PowerOff() override;
 
 };
 

--- a/Drivers/Marlin/Interfaces/libmcdriver_marlin_abi.hpp
+++ b/Drivers/Marlin/Interfaces/libmcdriver_marlin_abi.hpp
@@ -191,13 +191,21 @@ LIBMCDRIVER_MARLIN_DECLSPEC LibMCDriver_MarlinResult libmcdriver_marlin_driver_m
 LIBMCDRIVER_MARLIN_DECLSPEC LibMCDriver_MarlinResult libmcdriver_marlin_driver_marlin_setpidparameters(LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin, LibMCDriver_Marlin_double dP, LibMCDriver_Marlin_double dI, LibMCDriver_Marlin_double dD);
 
 /**
-* Polls a new state from the firmware.
+* Polls a new state from the printer.
+*
+* @param[in] pDriver_Marlin - Driver_Marlin instance.
+* @return error code or 0 (success)
+*/
+LIBMCDRIVER_MARLIN_DECLSPEC LibMCDriver_MarlinResult libmcdriver_marlin_driver_marlin_updatepositionstate(LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin);
+
+/**
+* Polls a new temperature state from the printer.
 *
 * @param[in] pDriver_Marlin - Driver_Marlin instance.
 * @param[in] nExtruderID - ID of extruder.
 * @return error code or 0 (success)
 */
-LIBMCDRIVER_MARLIN_DECLSPEC LibMCDriver_MarlinResult libmcdriver_marlin_driver_marlin_updatestate(LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin, LibMCDriver_Marlin_uint32 nExtruderID);
+LIBMCDRIVER_MARLIN_DECLSPEC LibMCDriver_MarlinResult libmcdriver_marlin_driver_marlin_updatetemperaturestate(LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin, LibMCDriver_Marlin_uint32 nExtruderID);
 
 /**
 * Returns the current axis position.
@@ -231,25 +239,42 @@ LIBMCDRIVER_MARLIN_DECLSPEC LibMCDriver_MarlinResult libmcdriver_marlin_driver_m
 LIBMCDRIVER_MARLIN_DECLSPEC LibMCDriver_MarlinResult libmcdriver_marlin_driver_marlin_getextrudertargetposition(LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin, LibMCDriver_Marlin_double * pE);
 
 /**
-* Returns the current and the target bed temperature.
+* Returns the the target bed temperature.
 *
 * @param[in] pDriver_Marlin - Driver_Marlin instance.
 * @param[out] pTargetTemperature - Target Temperature in degree celsius.
+* @return error code or 0 (success)
+*/
+LIBMCDRIVER_MARLIN_DECLSPEC LibMCDriver_MarlinResult libmcdriver_marlin_driver_marlin_getheatedbedtargettemperature(LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin, LibMCDriver_Marlin_double * pTargetTemperature);
+
+/**
+* Returns the current bed temperature.
+*
+* @param[in] pDriver_Marlin - Driver_Marlin instance.
 * @param[out] pCurrentTemperature - Current Temperature in degree celsius.
 * @return error code or 0 (success)
 */
-LIBMCDRIVER_MARLIN_DECLSPEC LibMCDriver_MarlinResult libmcdriver_marlin_driver_marlin_getheatedbedtemperature(LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin, LibMCDriver_Marlin_double * pTargetTemperature, LibMCDriver_Marlin_double * pCurrentTemperature);
+LIBMCDRIVER_MARLIN_DECLSPEC LibMCDriver_MarlinResult libmcdriver_marlin_driver_marlin_getheatedbedcurrenttemperature(LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin, LibMCDriver_Marlin_double * pCurrentTemperature);
 
 /**
-* Returns the current and the target temperature of an extruder.
+* Returns the current temperature of an extruder.
+*
+* @param[in] pDriver_Marlin - Driver_Marlin instance.
+* @param[in] nExtruderID - ID of Extruder
+* @param[out] pCurrentTemperature - Current Temperature in degree celsius.
+* @return error code or 0 (success)
+*/
+LIBMCDRIVER_MARLIN_DECLSPEC LibMCDriver_MarlinResult libmcdriver_marlin_driver_marlin_getextrudercurrenttemperature(LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin, LibMCDriver_Marlin_uint32 nExtruderID, LibMCDriver_Marlin_double * pCurrentTemperature);
+
+/**
+* Returns the target temperature of an extruder.
 *
 * @param[in] pDriver_Marlin - Driver_Marlin instance.
 * @param[in] nExtruderID - ID of Extruder
 * @param[out] pTargetTemperature - Target Temperature in degree celsius.
-* @param[out] pCurrentTemperature - Current Temperature in degree celsius.
 * @return error code or 0 (success)
 */
-LIBMCDRIVER_MARLIN_DECLSPEC LibMCDriver_MarlinResult libmcdriver_marlin_driver_marlin_getextrudertemperature(LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin, LibMCDriver_Marlin_uint32 nExtruderID, LibMCDriver_Marlin_double * pTargetTemperature, LibMCDriver_Marlin_double * pCurrentTemperature);
+LIBMCDRIVER_MARLIN_DECLSPEC LibMCDriver_MarlinResult libmcdriver_marlin_driver_marlin_getextrudertargettemperature(LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin, LibMCDriver_Marlin_uint32 nExtruderID, LibMCDriver_Marlin_double * pTargetTemperature);
 
 /**
 * Returns the current PID values.
@@ -357,6 +382,51 @@ LIBMCDRIVER_MARLIN_DECLSPEC LibMCDriver_MarlinResult libmcdriver_marlin_driver_m
 * @return error code or 0 (success)
 */
 LIBMCDRIVER_MARLIN_DECLSPEC LibMCDriver_MarlinResult libmcdriver_marlin_driver_marlin_emergencystop(LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin);
+
+/**
+* Set the current position of given axis to the specified value.
+*
+* @param[in] pDriver_Marlin - Driver_Marlin instance.
+* @param[in] pAxis - Axis whose value is to be set.
+* @param[in] dValue - New value for given Axis.
+* @return error code or 0 (success)
+*/
+LIBMCDRIVER_MARLIN_DECLSPEC LibMCDriver_MarlinResult libmcdriver_marlin_driver_marlin_setaxisposition(LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin, const char * pAxis, LibMCDriver_Marlin_double dValue);
+
+/**
+* Extrudes the specified value with given Feedrate.
+*
+* @param[in] pDriver_Marlin - Driver_Marlin instance.
+* @param[in] dE - E value in mm
+* @param[in] dSpeed - Extrusion speed in mm/s
+* @return error code or 0 (success)
+*/
+LIBMCDRIVER_MARLIN_DECLSPEC LibMCDriver_MarlinResult libmcdriver_marlin_driver_marlin_extruderdoextrude(LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin, LibMCDriver_Marlin_double dE, LibMCDriver_Marlin_double dSpeed);
+
+/**
+* Sets the extrusion (E axis) to absolute mode.
+*
+* @param[in] pDriver_Marlin - Driver_Marlin instance.
+* @param[in] bAbsolute - If true, sets mode to absolute, if false to relative
+* @return error code or 0 (success)
+*/
+LIBMCDRIVER_MARLIN_DECLSPEC LibMCDriver_MarlinResult libmcdriver_marlin_driver_marlin_setabsoluteextrusion(LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin, bool bAbsolute);
+
+/**
+* Stop the idle hold on all axis and extruder.
+*
+* @param[in] pDriver_Marlin - Driver_Marlin instance.
+* @return error code or 0 (success)
+*/
+LIBMCDRIVER_MARLIN_DECLSPEC LibMCDriver_MarlinResult libmcdriver_marlin_driver_marlin_stopidlehold(LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin);
+
+/**
+* Turn off the high-voltage power supply.
+*
+* @param[in] pDriver_Marlin - Driver_Marlin instance.
+* @return error code or 0 (success)
+*/
+LIBMCDRIVER_MARLIN_DECLSPEC LibMCDriver_MarlinResult libmcdriver_marlin_driver_marlin_poweroff(LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin);
 
 /*************************************************************************************************************************
  Global functions

--- a/Drivers/Marlin/Interfaces/libmcdriver_marlin_interfaces.hpp
+++ b/Drivers/Marlin/Interfaces/libmcdriver_marlin_interfaces.hpp
@@ -355,10 +355,15 @@ public:
 	virtual void SetPidParameters(const LibMCDriver_Marlin_double dP, const LibMCDriver_Marlin_double dI, const LibMCDriver_Marlin_double dD) = 0;
 
 	/**
-	* IDriver_Marlin::UpdateState - Polls a new state from the firmware.
+	* IDriver_Marlin::UpdatePositionState - Polls a new state from the printer.
+	*/
+	virtual void UpdatePositionState() = 0;
+
+	/**
+	* IDriver_Marlin::UpdateTemperatureState - Polls a new temperature state from the printer.
 	* @param[in] nExtruderID - ID of extruder.
 	*/
-	virtual void UpdateState(const LibMCDriver_Marlin_uint32 nExtruderID) = 0;
+	virtual void UpdateTemperatureState(const LibMCDriver_Marlin_uint32 nExtruderID) = 0;
 
 	/**
 	* IDriver_Marlin::GetCurrentPosition - Returns the current axis position.
@@ -383,19 +388,30 @@ public:
 	virtual void GetExtruderTargetPosition(LibMCDriver_Marlin_double & dE) = 0;
 
 	/**
-	* IDriver_Marlin::GetHeatedBedTemperature - Returns the current and the target bed temperature.
+	* IDriver_Marlin::GetHeatedBedTargetTemperature - Returns the the target bed temperature.
 	* @param[out] dTargetTemperature - Target Temperature in degree celsius.
-	* @param[out] dCurrentTemperature - Current Temperature in degree celsius.
 	*/
-	virtual void GetHeatedBedTemperature(LibMCDriver_Marlin_double & dTargetTemperature, LibMCDriver_Marlin_double & dCurrentTemperature) = 0;
+	virtual void GetHeatedBedTargetTemperature(LibMCDriver_Marlin_double & dTargetTemperature) = 0;
 
 	/**
-	* IDriver_Marlin::GetExtruderTemperature - Returns the current and the target temperature of an extruder.
-	* @param[in] nExtruderID - ID of Extruder
-	* @param[out] dTargetTemperature - Target Temperature in degree celsius.
+	* IDriver_Marlin::GetHeatedBedCurrentTemperature - Returns the current bed temperature.
 	* @param[out] dCurrentTemperature - Current Temperature in degree celsius.
 	*/
-	virtual void GetExtruderTemperature(const LibMCDriver_Marlin_uint32 nExtruderID, LibMCDriver_Marlin_double & dTargetTemperature, LibMCDriver_Marlin_double & dCurrentTemperature) = 0;
+	virtual void GetHeatedBedCurrentTemperature(LibMCDriver_Marlin_double & dCurrentTemperature) = 0;
+
+	/**
+	* IDriver_Marlin::GetExtruderCurrentTemperature - Returns the current temperature of an extruder.
+	* @param[in] nExtruderID - ID of Extruder
+	* @param[out] dCurrentTemperature - Current Temperature in degree celsius.
+	*/
+	virtual void GetExtruderCurrentTemperature(const LibMCDriver_Marlin_uint32 nExtruderID, LibMCDriver_Marlin_double & dCurrentTemperature) = 0;
+
+	/**
+	* IDriver_Marlin::GetExtruderTargetTemperature - Returns the target temperature of an extruder.
+	* @param[in] nExtruderID - ID of Extruder
+	* @param[out] dTargetTemperature - Target Temperature in degree celsius.
+	*/
+	virtual void GetExtruderTargetTemperature(const LibMCDriver_Marlin_uint32 nExtruderID, LibMCDriver_Marlin_double & dTargetTemperature) = 0;
 
 	/**
 	* IDriver_Marlin::GetPidParameters - Returns the current PID values.
@@ -470,6 +486,36 @@ public:
 	* IDriver_Marlin::EmergencyStop - Used for emergency stopping. Shuts down the machine, turns off all the steppers and heaters, and if possible, turns off the power supply.
 	*/
 	virtual void EmergencyStop() = 0;
+
+	/**
+	* IDriver_Marlin::SetAxisPosition - Set the current position of given axis to the specified value.
+	* @param[in] sAxis - Axis whose value is to be set.
+	* @param[in] dValue - New value for given Axis.
+	*/
+	virtual void SetAxisPosition(const std::string & sAxis, const LibMCDriver_Marlin_double dValue) = 0;
+
+	/**
+	* IDriver_Marlin::ExtruderDoExtrude - Extrudes the specified value with given Feedrate.
+	* @param[in] dE - E value in mm
+	* @param[in] dSpeed - Extrusion speed in mm/s
+	*/
+	virtual void ExtruderDoExtrude(const LibMCDriver_Marlin_double dE, const LibMCDriver_Marlin_double dSpeed) = 0;
+
+	/**
+	* IDriver_Marlin::SetAbsoluteExtrusion - Sets the extrusion (E axis) to absolute mode.
+	* @param[in] bAbsolute - If true, sets mode to absolute, if false to relative
+	*/
+	virtual void SetAbsoluteExtrusion(const bool bAbsolute) = 0;
+
+	/**
+	* IDriver_Marlin::StopIdleHold - Stop the idle hold on all axis and extruder.
+	*/
+	virtual void StopIdleHold() = 0;
+
+	/**
+	* IDriver_Marlin::PowerOff - Turn off the high-voltage power supply.
+	*/
+	virtual void PowerOff() = 0;
 
 };
 

--- a/Drivers/Marlin/Interfaces/libmcdriver_marlin_interfacewrapper.cpp
+++ b/Drivers/Marlin/Interfaces/libmcdriver_marlin_interfacewrapper.cpp
@@ -468,7 +468,7 @@ LibMCDriver_MarlinResult libmcdriver_marlin_driver_marlin_setpidparameters(LibMC
 	}
 }
 
-LibMCDriver_MarlinResult libmcdriver_marlin_driver_marlin_updatestate(LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin, LibMCDriver_Marlin_uint32 nExtruderID)
+LibMCDriver_MarlinResult libmcdriver_marlin_driver_marlin_updatepositionstate(LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin)
 {
 	IBase* pIBaseClass = (IBase *)pDriver_Marlin;
 
@@ -477,7 +477,31 @@ LibMCDriver_MarlinResult libmcdriver_marlin_driver_marlin_updatestate(LibMCDrive
 		if (!pIDriver_Marlin)
 			throw ELibMCDriver_MarlinInterfaceException(LIBMCDRIVER_MARLIN_ERROR_INVALIDCAST);
 		
-		pIDriver_Marlin->UpdateState(nExtruderID);
+		pIDriver_Marlin->UpdatePositionState();
+
+		return LIBMCDRIVER_MARLIN_SUCCESS;
+	}
+	catch (ELibMCDriver_MarlinInterfaceException & Exception) {
+		return handleLibMCDriver_MarlinException(pIBaseClass, Exception);
+	}
+	catch (std::exception & StdException) {
+		return handleStdException(pIBaseClass, StdException);
+	}
+	catch (...) {
+		return handleUnhandledException(pIBaseClass);
+	}
+}
+
+LibMCDriver_MarlinResult libmcdriver_marlin_driver_marlin_updatetemperaturestate(LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin, LibMCDriver_Marlin_uint32 nExtruderID)
+{
+	IBase* pIBaseClass = (IBase *)pDriver_Marlin;
+
+	try {
+		IDriver_Marlin* pIDriver_Marlin = dynamic_cast<IDriver_Marlin*>(pIBaseClass);
+		if (!pIDriver_Marlin)
+			throw ELibMCDriver_MarlinInterfaceException(LIBMCDRIVER_MARLIN_ERROR_INVALIDCAST);
+		
+		pIDriver_Marlin->UpdateTemperatureState(nExtruderID);
 
 		return LIBMCDRIVER_MARLIN_SUCCESS;
 	}
@@ -578,20 +602,18 @@ LibMCDriver_MarlinResult libmcdriver_marlin_driver_marlin_getextrudertargetposit
 	}
 }
 
-LibMCDriver_MarlinResult libmcdriver_marlin_driver_marlin_getheatedbedtemperature(LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin, LibMCDriver_Marlin_double * pTargetTemperature, LibMCDriver_Marlin_double * pCurrentTemperature)
+LibMCDriver_MarlinResult libmcdriver_marlin_driver_marlin_getheatedbedtargettemperature(LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin, LibMCDriver_Marlin_double * pTargetTemperature)
 {
 	IBase* pIBaseClass = (IBase *)pDriver_Marlin;
 
 	try {
 		if (!pTargetTemperature)
 			throw ELibMCDriver_MarlinInterfaceException (LIBMCDRIVER_MARLIN_ERROR_INVALIDPARAM);
-		if (!pCurrentTemperature)
-			throw ELibMCDriver_MarlinInterfaceException (LIBMCDRIVER_MARLIN_ERROR_INVALIDPARAM);
 		IDriver_Marlin* pIDriver_Marlin = dynamic_cast<IDriver_Marlin*>(pIBaseClass);
 		if (!pIDriver_Marlin)
 			throw ELibMCDriver_MarlinInterfaceException(LIBMCDRIVER_MARLIN_ERROR_INVALIDCAST);
 		
-		pIDriver_Marlin->GetHeatedBedTemperature(*pTargetTemperature, *pCurrentTemperature);
+		pIDriver_Marlin->GetHeatedBedTargetTemperature(*pTargetTemperature);
 
 		return LIBMCDRIVER_MARLIN_SUCCESS;
 	}
@@ -606,20 +628,70 @@ LibMCDriver_MarlinResult libmcdriver_marlin_driver_marlin_getheatedbedtemperatur
 	}
 }
 
-LibMCDriver_MarlinResult libmcdriver_marlin_driver_marlin_getextrudertemperature(LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin, LibMCDriver_Marlin_uint32 nExtruderID, LibMCDriver_Marlin_double * pTargetTemperature, LibMCDriver_Marlin_double * pCurrentTemperature)
+LibMCDriver_MarlinResult libmcdriver_marlin_driver_marlin_getheatedbedcurrenttemperature(LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin, LibMCDriver_Marlin_double * pCurrentTemperature)
 {
 	IBase* pIBaseClass = (IBase *)pDriver_Marlin;
 
 	try {
-		if (!pTargetTemperature)
-			throw ELibMCDriver_MarlinInterfaceException (LIBMCDRIVER_MARLIN_ERROR_INVALIDPARAM);
 		if (!pCurrentTemperature)
 			throw ELibMCDriver_MarlinInterfaceException (LIBMCDRIVER_MARLIN_ERROR_INVALIDPARAM);
 		IDriver_Marlin* pIDriver_Marlin = dynamic_cast<IDriver_Marlin*>(pIBaseClass);
 		if (!pIDriver_Marlin)
 			throw ELibMCDriver_MarlinInterfaceException(LIBMCDRIVER_MARLIN_ERROR_INVALIDCAST);
 		
-		pIDriver_Marlin->GetExtruderTemperature(nExtruderID, *pTargetTemperature, *pCurrentTemperature);
+		pIDriver_Marlin->GetHeatedBedCurrentTemperature(*pCurrentTemperature);
+
+		return LIBMCDRIVER_MARLIN_SUCCESS;
+	}
+	catch (ELibMCDriver_MarlinInterfaceException & Exception) {
+		return handleLibMCDriver_MarlinException(pIBaseClass, Exception);
+	}
+	catch (std::exception & StdException) {
+		return handleStdException(pIBaseClass, StdException);
+	}
+	catch (...) {
+		return handleUnhandledException(pIBaseClass);
+	}
+}
+
+LibMCDriver_MarlinResult libmcdriver_marlin_driver_marlin_getextrudercurrenttemperature(LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin, LibMCDriver_Marlin_uint32 nExtruderID, LibMCDriver_Marlin_double * pCurrentTemperature)
+{
+	IBase* pIBaseClass = (IBase *)pDriver_Marlin;
+
+	try {
+		if (!pCurrentTemperature)
+			throw ELibMCDriver_MarlinInterfaceException (LIBMCDRIVER_MARLIN_ERROR_INVALIDPARAM);
+		IDriver_Marlin* pIDriver_Marlin = dynamic_cast<IDriver_Marlin*>(pIBaseClass);
+		if (!pIDriver_Marlin)
+			throw ELibMCDriver_MarlinInterfaceException(LIBMCDRIVER_MARLIN_ERROR_INVALIDCAST);
+		
+		pIDriver_Marlin->GetExtruderCurrentTemperature(nExtruderID, *pCurrentTemperature);
+
+		return LIBMCDRIVER_MARLIN_SUCCESS;
+	}
+	catch (ELibMCDriver_MarlinInterfaceException & Exception) {
+		return handleLibMCDriver_MarlinException(pIBaseClass, Exception);
+	}
+	catch (std::exception & StdException) {
+		return handleStdException(pIBaseClass, StdException);
+	}
+	catch (...) {
+		return handleUnhandledException(pIBaseClass);
+	}
+}
+
+LibMCDriver_MarlinResult libmcdriver_marlin_driver_marlin_getextrudertargettemperature(LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin, LibMCDriver_Marlin_uint32 nExtruderID, LibMCDriver_Marlin_double * pTargetTemperature)
+{
+	IBase* pIBaseClass = (IBase *)pDriver_Marlin;
+
+	try {
+		if (!pTargetTemperature)
+			throw ELibMCDriver_MarlinInterfaceException (LIBMCDRIVER_MARLIN_ERROR_INVALIDPARAM);
+		IDriver_Marlin* pIDriver_Marlin = dynamic_cast<IDriver_Marlin*>(pIBaseClass);
+		if (!pIDriver_Marlin)
+			throw ELibMCDriver_MarlinInterfaceException(LIBMCDRIVER_MARLIN_ERROR_INVALIDCAST);
+		
+		pIDriver_Marlin->GetExtruderTargetTemperature(nExtruderID, *pTargetTemperature);
 
 		return LIBMCDRIVER_MARLIN_SUCCESS;
 	}
@@ -912,6 +984,129 @@ LibMCDriver_MarlinResult libmcdriver_marlin_driver_marlin_emergencystop(LibMCDri
 	}
 }
 
+LibMCDriver_MarlinResult libmcdriver_marlin_driver_marlin_setaxisposition(LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin, const char * pAxis, LibMCDriver_Marlin_double dValue)
+{
+	IBase* pIBaseClass = (IBase *)pDriver_Marlin;
+
+	try {
+		if (pAxis == nullptr)
+			throw ELibMCDriver_MarlinInterfaceException (LIBMCDRIVER_MARLIN_ERROR_INVALIDPARAM);
+		std::string sAxis(pAxis);
+		IDriver_Marlin* pIDriver_Marlin = dynamic_cast<IDriver_Marlin*>(pIBaseClass);
+		if (!pIDriver_Marlin)
+			throw ELibMCDriver_MarlinInterfaceException(LIBMCDRIVER_MARLIN_ERROR_INVALIDCAST);
+		
+		pIDriver_Marlin->SetAxisPosition(sAxis, dValue);
+
+		return LIBMCDRIVER_MARLIN_SUCCESS;
+	}
+	catch (ELibMCDriver_MarlinInterfaceException & Exception) {
+		return handleLibMCDriver_MarlinException(pIBaseClass, Exception);
+	}
+	catch (std::exception & StdException) {
+		return handleStdException(pIBaseClass, StdException);
+	}
+	catch (...) {
+		return handleUnhandledException(pIBaseClass);
+	}
+}
+
+LibMCDriver_MarlinResult libmcdriver_marlin_driver_marlin_extruderdoextrude(LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin, LibMCDriver_Marlin_double dE, LibMCDriver_Marlin_double dSpeed)
+{
+	IBase* pIBaseClass = (IBase *)pDriver_Marlin;
+
+	try {
+		IDriver_Marlin* pIDriver_Marlin = dynamic_cast<IDriver_Marlin*>(pIBaseClass);
+		if (!pIDriver_Marlin)
+			throw ELibMCDriver_MarlinInterfaceException(LIBMCDRIVER_MARLIN_ERROR_INVALIDCAST);
+		
+		pIDriver_Marlin->ExtruderDoExtrude(dE, dSpeed);
+
+		return LIBMCDRIVER_MARLIN_SUCCESS;
+	}
+	catch (ELibMCDriver_MarlinInterfaceException & Exception) {
+		return handleLibMCDriver_MarlinException(pIBaseClass, Exception);
+	}
+	catch (std::exception & StdException) {
+		return handleStdException(pIBaseClass, StdException);
+	}
+	catch (...) {
+		return handleUnhandledException(pIBaseClass);
+	}
+}
+
+LibMCDriver_MarlinResult libmcdriver_marlin_driver_marlin_setabsoluteextrusion(LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin, bool bAbsolute)
+{
+	IBase* pIBaseClass = (IBase *)pDriver_Marlin;
+
+	try {
+		IDriver_Marlin* pIDriver_Marlin = dynamic_cast<IDriver_Marlin*>(pIBaseClass);
+		if (!pIDriver_Marlin)
+			throw ELibMCDriver_MarlinInterfaceException(LIBMCDRIVER_MARLIN_ERROR_INVALIDCAST);
+		
+		pIDriver_Marlin->SetAbsoluteExtrusion(bAbsolute);
+
+		return LIBMCDRIVER_MARLIN_SUCCESS;
+	}
+	catch (ELibMCDriver_MarlinInterfaceException & Exception) {
+		return handleLibMCDriver_MarlinException(pIBaseClass, Exception);
+	}
+	catch (std::exception & StdException) {
+		return handleStdException(pIBaseClass, StdException);
+	}
+	catch (...) {
+		return handleUnhandledException(pIBaseClass);
+	}
+}
+
+LibMCDriver_MarlinResult libmcdriver_marlin_driver_marlin_stopidlehold(LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin)
+{
+	IBase* pIBaseClass = (IBase *)pDriver_Marlin;
+
+	try {
+		IDriver_Marlin* pIDriver_Marlin = dynamic_cast<IDriver_Marlin*>(pIBaseClass);
+		if (!pIDriver_Marlin)
+			throw ELibMCDriver_MarlinInterfaceException(LIBMCDRIVER_MARLIN_ERROR_INVALIDCAST);
+		
+		pIDriver_Marlin->StopIdleHold();
+
+		return LIBMCDRIVER_MARLIN_SUCCESS;
+	}
+	catch (ELibMCDriver_MarlinInterfaceException & Exception) {
+		return handleLibMCDriver_MarlinException(pIBaseClass, Exception);
+	}
+	catch (std::exception & StdException) {
+		return handleStdException(pIBaseClass, StdException);
+	}
+	catch (...) {
+		return handleUnhandledException(pIBaseClass);
+	}
+}
+
+LibMCDriver_MarlinResult libmcdriver_marlin_driver_marlin_poweroff(LibMCDriver_Marlin_Driver_Marlin pDriver_Marlin)
+{
+	IBase* pIBaseClass = (IBase *)pDriver_Marlin;
+
+	try {
+		IDriver_Marlin* pIDriver_Marlin = dynamic_cast<IDriver_Marlin*>(pIBaseClass);
+		if (!pIDriver_Marlin)
+			throw ELibMCDriver_MarlinInterfaceException(LIBMCDRIVER_MARLIN_ERROR_INVALIDCAST);
+		
+		pIDriver_Marlin->PowerOff();
+
+		return LIBMCDRIVER_MARLIN_SUCCESS;
+	}
+	catch (ELibMCDriver_MarlinInterfaceException & Exception) {
+		return handleLibMCDriver_MarlinException(pIBaseClass, Exception);
+	}
+	catch (std::exception & StdException) {
+		return handleStdException(pIBaseClass, StdException);
+	}
+	catch (...) {
+		return handleUnhandledException(pIBaseClass);
+	}
+}
+
 
 
 /*************************************************************************************************************************
@@ -949,18 +1144,24 @@ LibMCDriver_MarlinResult LibMCDriver_Marlin::Impl::LibMCDriver_Marlin_GetProcAdd
 		*ppProcAddress = (void*) &libmcdriver_marlin_driver_marlin_setfanspeed;
 	if (sProcName == "libmcdriver_marlin_driver_marlin_setpidparameters") 
 		*ppProcAddress = (void*) &libmcdriver_marlin_driver_marlin_setpidparameters;
-	if (sProcName == "libmcdriver_marlin_driver_marlin_updatestate") 
-		*ppProcAddress = (void*) &libmcdriver_marlin_driver_marlin_updatestate;
+	if (sProcName == "libmcdriver_marlin_driver_marlin_updatepositionstate") 
+		*ppProcAddress = (void*) &libmcdriver_marlin_driver_marlin_updatepositionstate;
+	if (sProcName == "libmcdriver_marlin_driver_marlin_updatetemperaturestate") 
+		*ppProcAddress = (void*) &libmcdriver_marlin_driver_marlin_updatetemperaturestate;
 	if (sProcName == "libmcdriver_marlin_driver_marlin_getcurrentposition") 
 		*ppProcAddress = (void*) &libmcdriver_marlin_driver_marlin_getcurrentposition;
 	if (sProcName == "libmcdriver_marlin_driver_marlin_gettargetposition") 
 		*ppProcAddress = (void*) &libmcdriver_marlin_driver_marlin_gettargetposition;
 	if (sProcName == "libmcdriver_marlin_driver_marlin_getextrudertargetposition") 
 		*ppProcAddress = (void*) &libmcdriver_marlin_driver_marlin_getextrudertargetposition;
-	if (sProcName == "libmcdriver_marlin_driver_marlin_getheatedbedtemperature") 
-		*ppProcAddress = (void*) &libmcdriver_marlin_driver_marlin_getheatedbedtemperature;
-	if (sProcName == "libmcdriver_marlin_driver_marlin_getextrudertemperature") 
-		*ppProcAddress = (void*) &libmcdriver_marlin_driver_marlin_getextrudertemperature;
+	if (sProcName == "libmcdriver_marlin_driver_marlin_getheatedbedtargettemperature") 
+		*ppProcAddress = (void*) &libmcdriver_marlin_driver_marlin_getheatedbedtargettemperature;
+	if (sProcName == "libmcdriver_marlin_driver_marlin_getheatedbedcurrenttemperature") 
+		*ppProcAddress = (void*) &libmcdriver_marlin_driver_marlin_getheatedbedcurrenttemperature;
+	if (sProcName == "libmcdriver_marlin_driver_marlin_getextrudercurrenttemperature") 
+		*ppProcAddress = (void*) &libmcdriver_marlin_driver_marlin_getextrudercurrenttemperature;
+	if (sProcName == "libmcdriver_marlin_driver_marlin_getextrudertargettemperature") 
+		*ppProcAddress = (void*) &libmcdriver_marlin_driver_marlin_getextrudertargettemperature;
 	if (sProcName == "libmcdriver_marlin_driver_marlin_getpidparameters") 
 		*ppProcAddress = (void*) &libmcdriver_marlin_driver_marlin_getpidparameters;
 	if (sProcName == "libmcdriver_marlin_driver_marlin_canexecutemovement") 
@@ -983,6 +1184,16 @@ LibMCDriver_MarlinResult LibMCDriver_Marlin::Impl::LibMCDriver_Marlin_GetProcAdd
 		*ppProcAddress = (void*) &libmcdriver_marlin_driver_marlin_starthoming;
 	if (sProcName == "libmcdriver_marlin_driver_marlin_emergencystop") 
 		*ppProcAddress = (void*) &libmcdriver_marlin_driver_marlin_emergencystop;
+	if (sProcName == "libmcdriver_marlin_driver_marlin_setaxisposition") 
+		*ppProcAddress = (void*) &libmcdriver_marlin_driver_marlin_setaxisposition;
+	if (sProcName == "libmcdriver_marlin_driver_marlin_extruderdoextrude") 
+		*ppProcAddress = (void*) &libmcdriver_marlin_driver_marlin_extruderdoextrude;
+	if (sProcName == "libmcdriver_marlin_driver_marlin_setabsoluteextrusion") 
+		*ppProcAddress = (void*) &libmcdriver_marlin_driver_marlin_setabsoluteextrusion;
+	if (sProcName == "libmcdriver_marlin_driver_marlin_stopidlehold") 
+		*ppProcAddress = (void*) &libmcdriver_marlin_driver_marlin_stopidlehold;
+	if (sProcName == "libmcdriver_marlin_driver_marlin_poweroff") 
+		*ppProcAddress = (void*) &libmcdriver_marlin_driver_marlin_poweroff;
 	if (sProcName == "libmcdriver_marlin_getversion") 
 		*ppProcAddress = (void*) &libmcdriver_marlin_getversion;
 	if (sProcName == "libmcdriver_marlin_getlasterror") 

--- a/Plugins/Main/mcplugin_main.cpp
+++ b/Plugins/Main/mcplugin_main.cpp
@@ -63,6 +63,75 @@ public:
 		return m_DriverCast_RaspiCamera.acquireDriver(pStateEnvironment, "camera");
 	}
 
+	void setFanSpeed(LibMCEnv::PStateEnvironment pStateEnvironment, uint32_t nFanId, double dFanSpeed)
+	{
+		// set temperature without waiting => already heating while homing
+		pStateEnvironment->LogMessage("Set fan speed. ");
+		auto pSignal = pStateEnvironment->PrepareSignal("printerconnection", "signal_setfanspeed");
+		pSignal->SetInteger("fanid", nFanId);
+		pSignal->SetDouble("fanspeed", dFanSpeed);
+		pSignal->Trigger();
+
+		if (pSignal->WaitForHandling(1000)) {
+			if (pSignal->GetBoolResult("success")) {
+				pStateEnvironment->LogMessage("Fan speed set successful. ");
+			}
+			else {
+				pStateEnvironment->LogWarning("Set fan speed failure. ");
+			}
+		}
+		else {
+			pStateEnvironment->LogWarning("Set fan speed timeout!");
+		}
+	}
+
+	void doFinalizeExtrude(LibMCEnv::PStateEnvironment pStateEnvironment)
+	{
+		// send signal to finalize extrude process
+		pStateEnvironment->LogMessage("Finalize extrude. ");
+		auto pSignal = pStateEnvironment->PrepareSignal("printerconnection", "signal_dofinalizeextrude");
+		pSignal->Trigger();
+
+		if (pSignal->WaitForHandling(5000)) {
+			if (pSignal->GetBoolResult("success")) {
+				pStateEnvironment->LogMessage("Finalize extrude successful. ");
+			}
+			else {
+				pStateEnvironment->LogWarning("Finalize extrude failure. ");
+			}
+		}
+		else {
+			pStateEnvironment->LogWarning("Finalize extrudetimeout!");
+		}
+	}
+
+	void setTemperatureWithoutWaiting(LibMCEnv::PStateEnvironment pStateEnvironment, uint32_t nExtruderId, double dExtruderTargetTemperature, double dBedTargetTemperature)
+	{
+		// set temperature without waiting => already heating while homing
+		pStateEnvironment->LogMessage("Set bed and extruder temperature without waiting. ");
+		auto pSignal = pStateEnvironment->PrepareSignal("printerconnection", "signal_settemperature");
+		pSignal->SetBool("bedsetvalue", true);
+		pSignal->SetDouble("bedtemperature", dBedTargetTemperature);
+		pSignal->SetBool("beddowait", false);
+		pSignal->SetBool("extrudersetvalue", true);
+		pSignal->SetInteger("extruderid", nExtruderId);
+		pSignal->SetDouble("extrudertemperature", dExtruderTargetTemperature);
+		pSignal->SetBool("extruderdowait", false);
+		pSignal->Trigger();
+
+		if (pSignal->WaitForHandling(1000)) {
+			if (pSignal->GetBoolResult("success")) {
+				pStateEnvironment->LogMessage("Temperature set successful. ");
+			}
+			else {
+				pStateEnvironment->LogWarning("Set Temperature failure. ");
+			}
+		}
+		else {
+			pStateEnvironment->LogWarning("Set Temperature timeout!");
+		}
+	}
+
 };
 
 /*************************************************************************************************************************
@@ -160,7 +229,7 @@ public:
 					pStateEnvironment->SetNextState("startprocess");
 				}
 				catch (std::exception& E) {
-					pStateEnvironment->LogMessage (std::string ("Could not start job: ") + E.what ());
+					pStateEnvironment->LogWarning(std::string ("Could not start job: ") + E.what ());
 					pHandlerInstance->SetBoolResult("success", false);
 					pStateEnvironment->SetNextState("idle");
 				}
@@ -221,6 +290,20 @@ public:
 		pStateEnvironment->SetBoolParameter("jobinfo", "autostart", false);
 		pStateEnvironment->SetBoolParameter("jobinfo", "printinprogress", true);
 		
+		auto nExtruderId = pStateEnvironment->GetIntegerParameter("temperaturecontrol", "extruderid");
+		auto dExtruderTargetTemperature = pStateEnvironment->GetDoubleParameter("temperaturecontrol", "targetextrudertemperature");
+		auto dBedTargetTemperature = pStateEnvironment->GetDoubleParameter("temperaturecontrol", "targetbedtemperature");
+		// store read values => to be used in other state of main state machine (waitfortemperature)
+		pStateEnvironment->StoreInteger("extruderid", nExtruderId);
+		pStateEnvironment->StoreDouble("extrudertargettemperature", dExtruderTargetTemperature);
+		pStateEnvironment->StoreDouble("bedtargettemperature", dBedTargetTemperature);
+
+		auto nFanId = pStateEnvironment->GetIntegerParameter("temperaturecontrol", "fanid");
+		auto dFanSpeed = pStateEnvironment->GetDoubleParameter("temperaturecontrol", "fanspeed");
+		// store read values => to be used in other state of main state machine (finish process)
+		pStateEnvironment->StoreInteger("fanid", nFanId);
+		pStateEnvironment->StoreDouble("fanspeed", dFanSpeed);
+
 		auto pSignalIsConnected = pStateEnvironment->PrepareSignal("printerconnection", "signal_isconnected");
 		pSignalIsConnected->Trigger();
 
@@ -229,15 +312,40 @@ public:
 
 			if (bSuccess) {
 				pStateEnvironment->LogMessage("Printer connected. ");
-				pStateEnvironment->SetNextState("waitfortemperature");
+				// set desired temperature and don't wait 
+				m_pPluginData->setTemperatureWithoutWaiting(pStateEnvironment, nExtruderId, dExtruderTargetTemperature, dBedTargetTemperature);
+				
+				// check if printer is homed and do homing if necessary
+				auto pSignalDoHoming = pStateEnvironment->PrepareSignal("printerconnection", "signal_dohoming");
+				pSignalDoHoming->Trigger();
+
+				if (pSignalDoHoming->WaitForHandling((uint32_t)(20000))) {
+					bSuccess = pSignalDoHoming->GetBoolResult("success");
+
+					if (bSuccess) {
+						pStateEnvironment->LogMessage("Printer homed. ");
+
+						// do some initialization stuff
+						// set flag to tell state "waitfortemperature" to initialize extruder (will be done just once, while starting)
+						pStateEnvironment->StoreBool("extruderdoinit", true);
+						// set fan speed
+						m_pPluginData->setFanSpeed(pStateEnvironment, nFanId, dFanSpeed);
+						// and now wait for temperature
+						pStateEnvironment->SetNextState("waitfortemperature");
+					}
+					else {
+						pStateEnvironment->LogWarning("Printer not homed. ");
+						pStateEnvironment->SetNextState("fatalerror");
+					}
+				}
 			}
 			else {
-				pStateEnvironment->LogMessage("Printer not connected. ");
+				pStateEnvironment->LogWarning("Printer not connected. ");
 				pStateEnvironment->SetNextState("fatalerror");
 			}
 		}
 		else {
-			pStateEnvironment->LogMessage("Signal 'Printer is connected' timeout. ");
+			pStateEnvironment->LogWarning("Signal 'Printer is connected' timeout. ");
 			pStateEnvironment->SetNextState("fatalerror");
 		}
 
@@ -271,12 +379,10 @@ public:
 			throw ELibMCPluginInterfaceException(LIBMCPLUGIN_ERROR_INVALIDPARAM);
 
 		pStateEnvironment->LogMessage("Wait for temperature...");
-
-		// TODO get bed/extruder temperature (from somewhere) to set ...
-		uint32_t nExtruderId = 0;
-		double dExtruderTargetTemperature = 25.0;
-		double dBedTargetTemperature = 25.0;
-
+		uint32_t nExtruderId = pStateEnvironment->RetrieveBool("extruderid");
+		double dExtruderTargetTemperature = pStateEnvironment->RetrieveDouble("extrudertargettemperature");
+		double dBedTargetTemperature = pStateEnvironment->RetrieveDouble("bedtargettemperature");
+		
 		auto pSignal = pStateEnvironment->PrepareSignal("printerconnection", "signal_settemperature");
 		pSignal->SetBool("bedsetvalue", true);
 		pSignal->SetDouble("bedtemperature", dBedTargetTemperature);
@@ -290,53 +396,71 @@ public:
 		if (pSignal->WaitForHandling(10000)) {
 			auto bSuccess = pSignal->GetBoolResult("success");
 
-			// TODO get info if we want to wait until temperature is reached (from somewhere), maybe we just want to wait the first time (after connect/homing)
-			bool bBedDoWait = true;
-			bool bExtruderDoWait = true;
+			// wait for defined temperature 
+			LibMCEnv::PSignalHandler pSignalHandler;
+			double dBedTemperature = -1;
+			double dExtruderTemperature = -1;
 
-			if (bBedDoWait || bExtruderDoWait) {
-				// wait for defined temperature 
-				LibMCEnv::PSignalHandler pSignalHandler;
-				double dBedTemperature = -1;
-				double dExtruderTemperature = -1;
-
-				while ((bExtruderDoWait && (dExtruderTemperature < dExtruderTargetTemperature)) ||
-					(bBedDoWait && (dBedTemperature < dBedTargetTemperature))) {
-					
-					if (pStateEnvironment->WaitForSignal("signal_gettemperature", 0, pSignalHandler)) {
-						bool bBedGetValue = pSignalHandler->GetDouble("bedgetvalue");
-						if (bBedGetValue) {
-							dBedTemperature = pSignalHandler->GetDouble("bedtemperature");
-						}
-
-						bool bExtruderGetValue = pSignalHandler->GetDouble("extrudergetvalue");
-						if (bExtruderGetValue) {
-							//uint32_t nExtruderId = pSignalHandler->GetDouble("extruderid");
-							dExtruderTemperature = pSignalHandler->GetDouble("extrudertemperature");
-						}
-						pSignalHandler->SetBoolResult("success", true);
-						pSignalHandler->SignalHandled();
-
-						pStateEnvironment->LogMessage("Wait for temperature: E=" + std::to_string(dExtruderTemperature) + " B=" + std::to_string(dBedTemperature));
+			while ((dExtruderTemperature < dExtruderTargetTemperature) || (dBedTemperature < dBedTargetTemperature)) {
+				if (pStateEnvironment->WaitForSignal("signal_gettemperature", 0, pSignalHandler)) {
+					bool bBedGetValue = pSignalHandler->GetDouble("bedgetvalue");
+					if (bBedGetValue) {
+						dBedTemperature = pSignalHandler->GetDouble("bedtemperature");
 					}
-					pStateEnvironment->Sleep(100);
+					uint32_t nExtruderId = -1;
+					bool bExtruderGetValue = pSignalHandler->GetDouble("extrudergetvalue");
+					if (bExtruderGetValue) {
+						nExtruderId = pSignalHandler->GetDouble("extruderid");
+						dExtruderTemperature = pSignalHandler->GetDouble("extrudertemperature");
+					}
+					pSignalHandler->SetBoolResult("success", true);
+					pSignalHandler->SignalHandled();
 
-					// TODO add timeout/cancellation of "Wait for temperature"
+					pStateEnvironment->LogMessage("Wait for temperature: Eid" + std::to_string(nExtruderId) + "=" + std::to_string(dExtruderTemperature) + " B=" + std::to_string(dBedTemperature));
 				}
+				pStateEnvironment->Sleep(250);
+
+				// TODO add timeout/cancellation of "Wait for temperature"
 			}
 
 			if (bSuccess) {
 				pStateEnvironment->LogMessage("Temperature set successful. ");
-				pStateEnvironment->SetNextState("extrudelayer");
+
+				bool bSuccessExtruderInit = true;
+				// if called first time extruderdoinit should be set (by "startprocess") => initialize extruder
+				if (pStateEnvironment->RetrieveBool("extruderdoinit")) {
+					// do extruder initialization just once (at the beginning/first call) of "waitfortemperature" => reset flag
+					pStateEnvironment->StoreBool("extruderdoinit", false);
+					auto pSignalDoExtruderInit = pStateEnvironment->PrepareSignal("printerconnection", "signal_doextruderinit");
+					pSignalDoExtruderInit->Trigger();
+
+					if (pSignalDoExtruderInit->WaitForHandling((uint32_t)(5000))) {
+						bSuccessExtruderInit = pSignalDoExtruderInit->GetBoolResult("success");
+						if (bSuccessExtruderInit) {
+							pStateEnvironment->LogMessage("Extruder initilalized. ");
+						}
+					}
+					else {
+						bSuccessExtruderInit = false;
+					}
+				}
+				
+				if (bSuccessExtruderInit) {
+					// proceed to extrude current layer
+					pStateEnvironment->SetNextState("extrudelayer");
+				}
+				else {
+					pStateEnvironment->LogWarning("Extruder initialization error. ");
+					pStateEnvironment->SetNextState("fatalerror");
+				}
 			}
 			else {
-				pStateEnvironment->LogMessage("Set Temperature failure. ");
+				pStateEnvironment->LogWarning("Set Temperature failure. ");
 				pStateEnvironment->SetNextState("fatalerror");
 			}
 		}
 		else {
-
-			pStateEnvironment->LogMessage("Set Temperature timeout!");
+			pStateEnvironment->LogWarning("Set Temperature timeout!");
 			pStateEnvironment->SetNextState("fatalerror");
 		}
 	}
@@ -373,6 +497,17 @@ public:
 		// Unload Toolpath from memory
 		auto sJobUUID = pStateEnvironment->GetStringParameter("jobinfo", "jobuuid");
 		pStateEnvironment->GetBuildJob(sJobUUID)->UnloadToolpath ();
+
+		// stop fan
+		auto nFanId = pStateEnvironment->RetrieveInteger("fanid");
+		m_pPluginData->setFanSpeed(pStateEnvironment, nFanId, 0);
+		// switch off heating
+		uint32_t nExtruderId = pStateEnvironment->RetrieveBool("extruderid");
+		m_pPluginData->setTemperatureWithoutWaiting(pStateEnvironment, nExtruderId, 0.0, 0.0);
+		
+		// finalize extrude/print process (retract...)
+		m_pPluginData->doFinalizeExtrude(pStateEnvironment);
+
 
 		pStateEnvironment->SetBoolParameter("jobinfo", "printinprogress", false);
 
@@ -417,37 +552,57 @@ public:
 		if (nLayerTimeoutGraceTime < 0)
 			throw ELibMCPluginInterfaceException(LIBMCPLUGIN_ERROR_INVALIDPARAM);
 
-		// TODO get/calc timeout (from layer length, given speed....)
-		int64_t nLayerTimeout = 200000;
+		// send signal to restore filament to internally stored absolute E axis value ("ExtrudeValue") before extruding current layer
+		// retract filament is done by send signal "signal_retractfilament" (see NextLayer)
+		auto pSignalRestoreFilament = pStateEnvironment->PrepareSignal("printerconnection", "signal_restorefilament");
+		pSignalRestoreFilament->Trigger();
 
-		pStateEnvironment->LogMessage("Extrude layer #" + std::to_string(nCurrentLayer) + "...");
-
-		auto pSignal = pStateEnvironment->PrepareSignal("printerconnection", "signal_doextrudelayer");
-		pSignal->SetInteger("layertimeout", nLayerTimeout);
-		pSignal->SetInteger("layerindex", nCurrentLayer);
-		pSignal->SetString("jobuuid", sJobUUID);
-		pSignal->Trigger();
-
-		if (pSignal->WaitForHandling((uint32_t) (nLayerTimeout + nLayerTimeoutGraceTime))) {
-			auto bSuccess = pSignal->GetBoolResult("success");
+		if (pSignalRestoreFilament->WaitForHandling((uint32_t)(2000))) {
+			const auto bSuccess = pSignalRestoreFilament->GetBoolResult("success");
 
 			if (bSuccess) {
-				pStateEnvironment->LogMessage("Extruding success. ");
-				pStateEnvironment->SetNextState("nextlayer");
+				pStateEnvironment->LogMessage("Filament restored. ");
+				// proceed to extrude layer 
+
+				// TODO get/calc timeout (from layer length, given speed....)
+				int64_t nLayerTimeout = 200000;
+
+				pStateEnvironment->LogMessage("Extrude layer #" + std::to_string(nCurrentLayer) + "...");
+
+				auto pSignal = pStateEnvironment->PrepareSignal("printerconnection", "signal_doextrudelayer");
+				pSignal->SetInteger("layertimeout", nLayerTimeout);
+				pSignal->SetInteger("layerindex", nCurrentLayer);
+				pSignal->SetString("jobuuid", sJobUUID);
+				pSignal->Trigger();
+
+				if (pSignal->WaitForHandling((uint32_t)(nLayerTimeout + nLayerTimeoutGraceTime))) {
+					auto bSuccess = pSignal->GetBoolResult("success");
+
+					if (bSuccess) {
+						pStateEnvironment->LogMessage("Extruding success. ");
+						pStateEnvironment->SetNextState("nextlayer");
+					}
+					else {
+						pStateEnvironment->LogWarning("Extruding failure. ");
+						pStateEnvironment->SetNextState("fatalerror");
+					}
+				}
+				else {
+
+					pStateEnvironment->LogWarning("Extruding timeout!");
+					pStateEnvironment->SetNextState("fatalerror");
+				}
 			}
 			else {
-				pStateEnvironment->LogMessage("Extruding failure. ");
+				pStateEnvironment->LogWarning("Filament restore error.");
 				pStateEnvironment->SetNextState("fatalerror");
 			}
 		}
 		else {
-
-			pStateEnvironment->LogMessage("Extruding timeout!");
+			pStateEnvironment->LogWarning("Filament restore timeout. ");
 			pStateEnvironment->SetNextState("fatalerror");
 		}
-
 	}
-
 };
 
 
@@ -478,7 +633,6 @@ public:
 		auto nCurrentLayer = pStateEnvironment->GetIntegerParameter("jobinfo", "currentlayer");
 		auto nLayerCount = pStateEnvironment->GetIntegerParameter("jobinfo", "layercount");
 
-
 		// TODO activate/uncomment following lines to test emergency stop when proceeding to layer 3
 		//if (nCurrentLayer > 1) {
 		//	pStateEnvironment->LogMessage("Just for testing. call EMERGENCY STOP if layer #" + std::to_string(nCurrentLayer + 1) + " is next layer");
@@ -498,9 +652,32 @@ public:
 		//TODO uncomment to activate camera driver pBuild->AddBinaryData("image_layer_" + std::to_string(nCurrentLayer) + ".png", "image/png", Buffer);
 
 		if (nCurrentLayer < (nLayerCount - 1)) {
-			pStateEnvironment->LogMessage("Advancing to layer #" + std::to_string(nCurrentLayer + 1) + "...");
-			pStateEnvironment->SetIntegerParameter("jobinfo", "currentlayer", nCurrentLayer + 1);
-			pStateEnvironment->SetNextState("waitfortemperature");
+			// send signal to retract filament relatively before waiting for temperature (and extruding new layer)
+			// restore filament is done by send signal "signal_restorefilament" (see ExtrudeLayer)
+			auto pSignalRetractFilament = pStateEnvironment->PrepareSignal("printerconnection", "signal_retractfilament");
+			pSignalRetractFilament->Trigger();
+
+			if (pSignalRetractFilament->WaitForHandling((uint32_t)(2000))) {
+				const auto bSuccess = pSignalRetractFilament->GetBoolResult("success");
+
+				if (bSuccess) {
+					pStateEnvironment->LogMessage("Filament retracted. ");
+					// proceed to next layer and wait for temperature
+					pStateEnvironment->LogMessage("Advancing to layer #" + std::to_string(nCurrentLayer + 1) + "...");
+					pStateEnvironment->SetIntegerParameter("jobinfo", "currentlayer", nCurrentLayer + 1);
+
+					pStateEnvironment->SetNextState("waitfortemperature");
+				}
+				else {
+					pStateEnvironment->LogWarning("Filament retract error.");
+					pStateEnvironment->SetNextState("fatalerror");
+				}
+			}
+			else {
+				pStateEnvironment->LogWarning("Filament retract timeout. ");
+				pStateEnvironment->SetNextState("fatalerror");
+			}
+
 		}
 		else {
 			pStateEnvironment->LogMessage("Finishing process...");

--- a/Templates/libmcconfig.xml
+++ b/Templates/libmcconfig.xml
@@ -19,10 +19,13 @@
   	  </parametergroup>
 
   	  <parametergroup name="temperaturecontrol" description="Temperature Control">
+  		<parameter name="fanid" description="Fan ID to set target speed" default="0" type="int" />
+  		<parameter name="fanspeed" description="Fan Speed" default="128" type="double" />
+  		<parameter name="extruderid" description="Extruder ID to set/get target temperature" default="0" type="int" />
   		<parameter name="currentextrudertemperature" description="Current Extruder Temperature" default="0.0" type="double" />
-  		<parameter name="targetextrudertemperature" description="Target Extruder Temperature" default="0.0" type="double" />
-  		<parameter name="currentbedtemperature" description="Current Extruder Temperature" default="0.0" type="double" />
-  		<parameter name="targetbedtemperature" description="Target Extruder Temperature" default="0.0" type="double" />
+  		<parameter name="targetextrudertemperature" description="Target Extruder Temperature" default="25.0" type="double" />
+  		<parameter name="currentbedtemperature" description="Current Bed Temperature" default="0.0" type="double" />
+  		<parameter name="targetbedtemperature" description="Target Bed Temperature" default="25.0" type="double" />
   	  </parametergroup>
 
 	  
@@ -41,10 +44,8 @@
   		<result name="success" type="bool" />
   	  </signaldefinition>	 
 
-
   	  <state name="init" repeatdelay="100">
   			<outstate target="idle" />
-  			<outstate target="startprocess" />
   	  </state>
   
   
@@ -100,6 +101,14 @@
   		<result name="success" type="bool" />
   	  </signaldefinition>	 
 
+  	  <signaldefinition name="signal_dohoming">
+  		<result name="success" type="bool" />
+  	  </signaldefinition>	 
+
+  	  <signaldefinition name="signal_doextruderinit">
+  		<result name="success" type="bool" />
+  	  </signaldefinition>	 
+
 	  <signaldefinition name="signal_setpidvalues">
 		<parameter name="dp" type="double" />
 		<parameter name="di" type="double" />
@@ -126,6 +135,24 @@
   		<result name="success" type="bool" />
   	  </signaldefinition>	 
 
+  	  <signaldefinition name="signal_setfanspeed">
+  		<parameter name="fanid" type="int" />
+  		<parameter name="fanspeed" type="double" />
+  		<result name="success" type="bool" />
+  	  </signaldefinition>	 
+
+  	  <signaldefinition name="signal_dofinalizeextrude">
+  		<result name="success" type="bool" />
+  	  </signaldefinition>	 
+
+  	  <signaldefinition name="signal_retractfilament">
+  		<result name="success" type="bool" />
+  	  </signaldefinition>	 
+
+  	  <signaldefinition name="signal_restorefilament">
+  		<result name="success" type="bool" />
+  	  </signaldefinition>	 
+
   	  <parametergroup name="comdata" description="COM Configuration">		
   		<parameter name="port" description="COM Port" default="COM4" type="string" />
   		<parameter name="baudrate" description="Baud rate" default="115200" type="int" />
@@ -140,13 +167,6 @@
   		<parameter name="currentx" description="X Position" default="0" type="double" />
   		<parameter name="currenty" description="Y Position" default="0" type="double" />
   		<parameter name="currentz" description="Z Position" default="0" type="double" />
-  		<parameter name="defaultfanid" description="Fan ID to set target speed" default="0" type="int" />
-  		<parameter name="defaultfanspeed" description="Default Fan Speed" default="0" type="double" />
-  		<parameter name="defaulttargettemperatureextruderid" description="Default Extruder ID to set target temperature" default="0" type="int" />
-  		<parameter name="defaulttargettemperatureextruder" description="Default Target Extruder Temperature" default="0" type="double" />
-  		<parameter name="currenttemperatureextruder" description="Current Extruder Temperature" default="0" type="double" />
-  		<parameter name="defaulttargettemperaturebed" description="Default Target Bed Temperature" default="0" type="double" />
-  		<parameter name="currenttemperaturebed" description="Current Bed Temperature" default="0" type="double" />
   		<parameter name="ismoving" description="Moving" default="0" type="bool" />
       		<parameter name="ishomed" description="Homed" default="0" type="bool" />
       		<parameter name="isconnected" description="Connected" default="0" type="bool" />
@@ -160,18 +180,12 @@
   	     	    
   	  <state name="init" repeatdelay="100">
   			<outstate target="idle" />
-  			<outstate target="homing" />
   	  </state>
   
   
   	  <state name="idle" repeatdelay="50">	  	 
   			<outstate target="idle" />
-  			<outstate target="homing" />
   			<outstate target="doextrudelayer" />
-  	  </state>
-  
-  	  <state name="homing" repeatdelay="500">	  	  
-  			<outstate target="idle" />
   	  </state>
   
   	  <state name="doextrudelayer" repeatdelay="50">


### PR DESCRIPTION
THIS VERSION DOES NOT EXTRUDE! see comments "TODO XXXXX..."
Refactor program sequence. Homed, connected, temperature etc are now controlled by Main (using signals).

Main: set fan speed, initlialize extruder, set temperature without waiting, read target temperature from xml, finalize extrude process and retract/restore filament (layer change) added.

PrinterConnection/Marlin:
updateStateFromDriver renamed to updatePositionStateFromDriver now just updates printerstate parameters (positions...) and no more temperature.
Some functions moved to handleSignals.
UpdateFanSpeed added.
DoExtrudeLayer (and others) now call handleSignals in addition to updatePositionStateFromDriver.
Stored value "ExtrudeValue" used to save value of E axis after layer is finished => to be (re)used in next layer.
HandleSignals added => handles all signals received from Main
UpdatedState has been split => update position and temperature is done separately now.
State homing removed.