### PR TITLE
Refactoring, Manual Controls...

### DIFF
--- a/Drivers/Marlin/Implementation/AMC_SerialController_Marlin.cpp
+++ b/Drivers/Marlin/Implementation/AMC_SerialController_Marlin.cpp
@@ -156,7 +156,6 @@ namespace AMC {
 
 		if (!m_pConnection->isOpen()) {
 			m_pConnection.reset();
-			throw std::runtime_error("Could not connect to serial port");
 		}
 
 		// instead of waiting a fixed time wait until "start" or "" (after timeout) received from device??

--- a/Plugins/config.xml
+++ b/Plugins/config.xml
@@ -15,36 +15,37 @@
   		<parameter name="currentlayer" description="Current Layer" default="0" type="int" />
   		<parameter name="autostart" description="Automatically start job after init" default="0" type="bool" />
   		<parameter name="printinprogress" description="Print is in progress" default="0" type="bool" />
-  		<parameter name="layertimeoutgracetime" description="Grace time [ms] added to calculated layer timeout" default="1000" type="int" />
   	  </parametergroup>
 
   	  <parametergroup name="temperaturecontrol" description="Temperature Control">
   		<parameter name="fanid" description="Fan ID to set target speed" default="0" type="int" />
   		<parameter name="fanspeed" description="Fan Speed" default="128" type="double" />
   		<parameter name="extruderid" description="Extruder ID to set/get target temperature" default="0" type="int" />
-  		<parameter name="currentextrudertemperature" description="Current Extruder Temperature" default="0.0" type="double" />
   		<parameter name="targetextrudertemperature" description="Target Extruder Temperature" default="25.0" type="double" />
-  		<parameter name="currentbedtemperature" description="Current Bed Temperature" default="0.0" type="double" />
   		<parameter name="targetbedtemperature" description="Target Bed Temperature" default="25.0" type="double" />
   	  </parametergroup>
 
-  	  <parametergroup name="comdata" description="COM Configuration">		
-  		<parameter name="port" description="COM Port" default="COM4" type="string" />
-  		<parameter name="baudrate" description="Baud rate" default="115200" type="int" />
-		  <parameter name="connecttimeout" type="int" default="2000" description="Timeout [ms] for connecting printer" />
+  	  <parametergroup name="timeoutdata" description="Timeouts for different processes">		
+  		<parameter name="layergracetime" description="Grace time [ms] added to calculated layer timeout" default="1000" type="int" />
+		<parameter name="printerconnectandinitialise" type="int" default="20000" description="Timeout [ms] for connecting and initialising printer" />
   	  </parametergroup>
-	  	    	     	    
+
   	  <signaldefinition name="signal_startjob">
   		<parameter name="jobuuid" type="string" />
    		<parameter name="jobname" type="string" />
   		<result name="success" type="bool" />		
   	  </signaldefinition>	 	  	  	     
     
+  	  <signaldefinition name="signal_resetfatalerror">
+  		<result name="success" type="bool" />		
+  	  </signaldefinition>	 	  	  	     
+    
+  	  <signaldefinition name="signal_cleartemperatureandfan">
+  		<result name="success" type="bool" />
+  	  </signaldefinition>	 
+
   	  <signaldefinition name="signal_gettemperature">
-  		<parameter name="extrudergetvalue" type="bool" />
-  		<parameter name="extruderid" type="int" />
   		<parameter name="extrudertemperature" type="double" />
-  		<parameter name="bedgetvalue" type="bool" />
   		<parameter name="bedtemperature" type="double" />
   		<result name="success" type="bool" />
   	  </signaldefinition>	 
@@ -146,19 +147,23 @@
   		<result name="success" type="bool" />
   	  </signaldefinition>	 
 
+  	  <signaldefinition name="signal_resetfatalerror">
+  		<result name="success" type="bool" />		
+  	  </signaldefinition>	 	  	  	     
+    
 	  <parametergroup name="extrudedata" description="Extruder settings">
   		<parameter name="initialextrude" description="Value for initial extrusion" default="3" type="double" />
   		<parameter name="retractextrude" description="Value for retract/restore extrusion after/before each layer" default="1" type="double" />
 	  </parametergroup>
 
-	  <parametergroup name="comdata" description="COM Configuration">
-  		<derivedparameter name="port" statemachine="main" group="comdata" parameter="port" />
-  		<derivedparameter name="baudrate" statemachine="main" group="comdata" parameter="baudrate" />
-  		<derivedparameter name="connecttimeout" statemachine="main" group="comdata" parameter="connecttimeout" />
-	  </parametergroup>
+  	  <parametergroup name="comdata" description="COM Configuration">		
+  		<parameter name="port" description="COM Port" default="COM4" type="string" />
+  		<parameter name="baudrate" description="Baud rate" default="115200" type="int" />
+		<parameter name="connectinitialresponsetimeout" type="int" default="2000" description="Timeout [ms] for initial response of printer while connecting" />
+  	  </parametergroup>
 
   	  <driverparametergroup name="printerstate" description="Printer State Data" driver="marlin" /> 
-
+	  
   	  <state name="init" repeatdelay="100">
   			<outstate target="idle" />
   	  </state>
@@ -192,6 +197,7 @@
 		<parameter name="dd" description="dD Value" default="0" type="double" />
 	  </parametergroup>
 
+	  
 	  <signaldefinition name="signal_startcontrolling">
 		<result name="success" type="bool" />		
 	  </signaldefinition>
@@ -300,7 +306,17 @@
 		</page>
 
 		<page name="manualcontrol">
-
+			<content name="manualcontrols" title="Printer Control" >
+				<paragraph text="Here you find some buttons to control the printer manually." />
+				<buttongroup>
+					<button caption="Connect" event="connect" targetpage="systemstatus"/>
+					<button caption="Home" event="home" targetpage="systemstatus"/>
+					<button caption="Clear Temperature & Fan" event="cleartemperatureandfan" targetpage="systemstatus"/>
+					<button caption="Error Reset" event="resetfatalerror" targetpage="systemstatus"/>
+					<button caption="Emergency Stop" event="emergencystop" targetpage="systemstatus"/>
+					<button caption="Disconnect" event="disconnect" targetpage="systemstatus"/>
+				</buttongroup>
+			</content>					
 		</page>
 
 


### PR DESCRIPTION
Driver/Printerconnection:
Move current temp to driver parameter.
Add signal to reset state machine to idle after fatal error. 
signal_gettemperature to report current temperature to calling statemachine.
Main:
signal_gettemperature to read current temperature from printerconnection. 
Necessary as long as bidirectional derived parameters are not available.
mc_userinterface:
Buttons/Events to control printer manually added
Add signal to reset state machine to idle after fatal error.