### PR TITLE
Linux x64 build

### DIFF
--- a/.github/build-linux-x64/Dockerfile
+++ b/.github/build-linux-x64/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu:20.10
+
+RUN apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get install -yq uuid-dev build-essential cmake nodejs git npm golang
+
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/build-linux-x64/action.yml
+++ b/.github/build-linux-x64/action.yml
@@ -1,0 +1,12 @@
+name: 'Build Linux x64'
+description: 'Build binaries for Linux x64'
+inputs:
+  buildscript:  # id of input
+    description: 'Path to the build script to run'
+    required: true
+    default: './build_clean.sh'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{ inputs.buildscript }}

--- a/.github/build-linux-x64/entrypoint.sh
+++ b/.github/build-linux-x64/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+
+cd $GITHUB_WORKSPACE
+
+sh -c "$INPUT_BUILDSCRIPT"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,12 @@
-on: [push]
+on:
+  push:
+    branches:
+      - master
+      - develop
+  pull_request:
+    branches:
+      - master
+      - develop
 
 jobs:
   build_linux_x64:
@@ -7,7 +15,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Run build in docker
+      - name: Run buildscript in docker
         uses: ./.github/build-linux-x64
         id: build
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,14 @@
+on: [push]
+
+jobs:
+  build_linux_x64:
+    runs-on: ubuntu-latest
+    name: Build binaries
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Run build in docker
+        uses: ./.github/build-linux-x64
+        id: build
+        with:
+          buildscript: './build_clean.sh'

--- a/build_clean.sh
+++ b/build_clean.sh
@@ -73,7 +73,7 @@ cd "$builddir/Client"
 npm install
 npm run build
 
-go run ../../Server/createDist.go ../Output $GITHASH 
+go run ../../Server/createDist.go ../Output $GITHASH
 
 cd "$builddir"
 

--- a/build_clean.sh
+++ b/build_clean.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 basepath="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 builddir="$basepath/build"


### PR DESCRIPTION
This PR 
- Sets the abort on errors flag in the linux build script:  -e  Exit immediately if a command exits with a non-zero status.
- Adds a basic github actions which runs a linux x64 build on each push event.

The performance could be improved by prebuilding and storing the docker image for example in Dockerhub. 
